### PR TITLE
docs: mock_http should be used as sync context manager

### DIFF
--- a/docs/mocking.md
+++ b/docs/mocking.md
@@ -86,7 +86,7 @@ from zapros.matchers import path
 
 async def main():
     async with AsyncClient() as client:
-        async with mock_http() as router:
+        with mock_http() as router:
             Mock.given(path("/api")).respond(
                 Response(status=200)
             ).mount(router)


### PR DESCRIPTION
I tried to use example code for mocking HTTP requests from this [page](http://localhost:5173/mocking.html) and found typo in docs - `mock_http` can be used only as sync context manager, not the async one.


Example of the code that found in docs:

```python
async def test_mock():  # my test to just run it
	# all code below is from the docs
    async with AsyncClient() as client:
        async with mock_http() as router:
            Mock.given(path("/api")).respond(
                Response(status=200)
            ).mount(router)
            response = await client.get(
                "https://api.example.com/api",
            )
            assert response.status == 200
```

Example of the issue:

```
    async def test_mock():
        async with AsyncClient() as client:
>           async with mock_http() as router:
                       ^^^^^^^^^^^
E           TypeError: 'mock_http' object does not support the asynchronous context manager protocol
```