### PR TITLE
docs: Improve wording of what `mock_http` patches

### DIFF
--- a/docs/mocking.md
+++ b/docs/mocking.md
@@ -69,7 +69,7 @@ with Client(handler=MockMiddleware(router)) as client:
 
 :::
 
-or, if you don't have access to the `Client` and can't easily inject a handler, you can use the `mock_http` context manager to patch the standard library's HTTP handling:
+or, if you don't have access to the `Client` and can't easily inject a handler, you can use the `mock_http` context manager to patch `zapros`'s default HTTP handling:
 
 ::: code-group
 


### PR DESCRIPTION
Refs https://github.com/kap-sh/zapros/blob/fd3063c6c1f5b42f401cd31dad57f1f18092e75b/src/zapros/mock.py#L73-L86