### PR TITLE
feat: add mock call tracking helpers

### DIFF
--- a/docs/mocking.md
+++ b/docs/mocking.md
@@ -1181,6 +1181,72 @@ router.verify()
 
 :::
 
+You can also make post-hoc assertions on a mock after the code under test runs. These assertions inspect recorded calls and do not change matching or exhaustion behavior.
+
+::: code-group
+
+```python [Async]
+import asyncio
+from zapros import AsyncClient, Response
+from zapros.mock import (
+    Mock,
+    MockMiddleware,
+    MockRouter,
+)
+from zapros.matchers import path
+
+router = MockRouter()
+
+mock = Mock.given(path("/api")).respond(
+    Response(status=200)
+).mount(router)
+
+
+async def main():
+    async with AsyncClient(
+        handler=MockMiddleware(router)
+    ) as client:
+        await client.get(
+            "https://api.example.com/api",
+        )
+
+    mock.assert_called_once()
+    assert mock.called
+    assert mock.call_count == 1
+    assert mock.calls[0].method == "GET"
+
+
+asyncio.run(main())
+```
+
+```python [Sync]
+from zapros import Client, Response
+from zapros.mock import (
+    Mock,
+    MockMiddleware,
+    MockRouter,
+)
+from zapros.matchers import path
+
+router = MockRouter()
+
+mock = Mock.given(path("/api")).respond(
+    Response(status=200)
+).mount(router)
+
+with Client(handler=MockMiddleware(router)) as client:
+    client.get(
+        "https://api.example.com/api",
+    )
+
+mock.assert_called_once()
+assert mock.called
+assert mock.call_count == 1
+assert mock.calls[0].method == "GET"
+```
+
+:::
+
 ## Once
 
 ::: code-group

--- a/src/zapros/_handlers/_mock.py
+++ b/src/zapros/_handlers/_mock.py
@@ -30,6 +30,7 @@ from ._async_base import (
 class Mock:
     def __init__(self) -> None:
         self.matchers: list[Matcher] = []
+        self.calls: list[Request] = []
         self._response: Response | None = None
         self._callback: Callable[[Request], Response] | BaseException | type[BaseException] | None = None
         self._expected_calls: int | None = None
@@ -75,6 +76,14 @@ class Mock:
         self._name = name
         return self
 
+    @property
+    def called(self) -> bool:
+        return bool(self.calls)
+
+    @property
+    def call_count(self) -> int:
+        return len(self.calls)
+
     def _is_exhausted(self) -> bool:
         return (
             self._expected_calls is not None and self._actual_calls >= self._expected_calls and self._expected_calls > 0
@@ -86,6 +95,7 @@ class Mock:
         return all(m.match(request) for m in self.matchers)
 
     def handle(self, request: Request) -> Response:
+        self.calls.append(request)
         self._actual_calls += 1
 
         if self._callback:
@@ -114,7 +124,20 @@ class Mock:
             name = self._name or "Mock"
             raise AssertionError(f"{name}: expected {self._expected_calls} calls, got {self._actual_calls}")
 
+    def assert_called(self) -> None:
+        if not self.called:
+            raise AssertionError(f"{self._name or 'Mock'} was not called")
+
+    def assert_not_called(self) -> None:
+        if self.called:
+            raise AssertionError(f"{self._name or 'Mock'} was unexpectedly called")
+
+    def assert_called_once(self) -> None:
+        if self.call_count != 1:
+            raise AssertionError(f"{self._name or 'Mock'} expected 1 call, got {self.call_count}")
+
     def reset(self) -> None:
+        self.calls.clear()
         self._actual_calls = 0
 
 

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -309,6 +309,66 @@ def test_mock_expect():
     mock.verify()
 
 
+def test_mock_tracks_calls():
+    mock = Mock.given(path("/api")).respond(Response(status=200))
+    first_request = Request(
+        URL("https://example.com/api"),
+        "GET",
+    )
+    second_request = Request(
+        URL("https://example.com/api"),
+        "POST",
+    )
+
+    assert not mock.called
+    assert mock.call_count == 0
+
+    mock.handle(first_request)
+    mock.handle(second_request)
+
+    assert mock.called
+    assert mock.call_count == 2
+    assert mock.calls == [first_request, second_request]
+
+
+def test_mock_assert_called_helpers():
+    mock = Mock.given(path("/api")).respond(Response(status=200))
+    request = Request(
+        URL("https://example.com/api"),
+        "GET",
+    )
+
+    with pytest.raises(AssertionError, match="Mock was not called"):
+        mock.assert_called()
+
+    mock.assert_not_called()
+
+    mock.handle(request)
+
+    mock.assert_called()
+    mock.assert_called_once()
+
+    with pytest.raises(AssertionError, match="Mock was unexpectedly called"):
+        mock.assert_not_called()
+
+
+def test_mock_assert_called_once_failure():
+    mock = Mock.given(path("/api")).respond(Response(status=200)).name("API Mock")
+    request = Request(
+        URL("https://example.com/api"),
+        "GET",
+    )
+
+    with pytest.raises(AssertionError, match="API Mock expected 1 call, got 0"):
+        mock.assert_called_once()
+
+    mock.handle(request)
+    mock.handle(request)
+
+    with pytest.raises(AssertionError, match="API Mock expected 1 call, got 2"):
+        mock.assert_called_once()
+
+
 def test_mock_expect_failure():
     mock = Mock.given(path("/api")).respond(Response(status=200)).expect(2).name("API Mock")
     request = Request(
@@ -368,6 +428,9 @@ def test_mock_reset():
     mock.verify()
 
     mock.reset()
+
+    assert not mock.called
+    assert mock.call_count == 0
 
     with pytest.raises(AssertionError):
         mock.verify()


### PR DESCRIPTION
Adds lightweight call tracking helpers to Mock so tests can inspect and assert mock usage directly.