### PR TITLE
feat: add support for WebSockets

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -74,6 +74,7 @@ export default defineConfig({
       {
         text: "Common Features",
         items: [
+          { text: "WebSockets", link: "/websockets" },
           { text: "Authentication", link: "/authentication" },
           { text: "Cookies", link: "/cookies" },
           { text: "Redirects", link: "/redirects" },

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,5 +32,9 @@ features:
   - icon: ⚡
     title: Async & Sync Support
     details: Use the same clean interface in both async and sync environments.
+
+  - icon: 🔗
+    title: WebSocket Support
+    details: A WebSocket client built on top of Zapros primitives.
 ---
 

--- a/docs/websockets.md
+++ b/docs/websockets.md
@@ -1,0 +1,275 @@
+# WebSockets
+
+Zapros ships with a WebSocket client built on top of [wsproto](https://python-hyper.org/projects/wsproto/), running on top of your Zapros `Client` / `AsyncClient`. The handshake goes through the client, so authentication, cookies, retries, and any custom handlers apply to WebSocket connections as well.
+
+## Installation
+
+WebSocket support requires the optional `wsproto` dependency:
+
+```bash
+pip install zapros[websocket]
+```
+
+If `wsproto` is not installed, calling `aconnect_ws` or `connect_ws` raises `RuntimeError`.
+
+## Basic usage
+
+Open a connection with `aconnect_ws` (async) or `connect_ws` (sync). Both are context managers that yield a WebSocket object and close the connection on exit.
+
+::: code-group
+
+```python [Async]
+from zapros.websocket import (
+    BinaryMessage,
+    TextMessage,
+    aconnect_ws,
+)
+
+async with aconnect_ws("wss://echo.example.com/ws") as ws:
+    await ws.send(TextMessage(data="hello"))
+
+    match await ws.recv():
+        case TextMessage(data=text):
+            print(f"text: {text}")
+        case BinaryMessage(data=raw):
+            print(f"binary: {len(raw)} bytes")
+```
+
+```python [Sync]
+from zapros.websocket import (
+    BinaryMessage,
+    TextMessage,
+    connect_ws,
+)
+
+with connect_ws("wss://echo.example.com/ws") as ws:
+    ws.send(TextMessage(data="hello"))
+
+    match ws.recv():
+        case TextMessage(data=text):
+            print(f"text: {text}")
+        case BinaryMessage(data=raw):
+            print(f"binary: {len(raw)} bytes")
+```
+
+:::
+
+## Message types
+
+All messages are tagged dataclasses. Use `match` or `isinstance` to discriminate:
+
+| Type            | Payload  | Direction  |
+| --------------- | -------- | ---------- |
+| `TextMessage`   | `str`    | both       |
+| `BinaryMessage` | `bytes`  | both       |
+| `PingMessage`   | `bytes`  | both       |
+| `PongMessage`   | `bytes`  | both       |
+| `CloseMessage`  | code + reason | both  |
+
+Pongs to incoming pings are sent automatically — you only need to handle `PingMessage` if you care about observing them.
+
+## Iterating messages
+
+WebSocket objects are iterable. Iteration yields application messages and stops cleanly when the peer sends a close frame.
+
+::: code-group
+
+```python [Async]
+from zapros.websocket import (
+    BinaryMessage,
+    TextMessage,
+    aconnect_ws,
+)
+
+async with aconnect_ws("wss://stream.example.com/ws") as ws:
+    async for message in ws:
+        match message:
+            case TextMessage(data=text):
+                print(text)
+            case BinaryMessage(data=raw):
+                print(len(raw))
+```
+
+```python [Sync]
+from zapros.websocket import (
+    BinaryMessage,
+    TextMessage,
+    connect_ws,
+)
+
+with connect_ws("wss://stream.example.com/ws") as ws:
+    for message in ws:
+        match message:
+            case TextMessage(data=text):
+                print(text)
+            case BinaryMessage(data=raw):
+                print(len(raw))
+```
+
+:::
+
+## Sending binary data
+
+Wrap `bytes` payloads in `BinaryMessage`:
+
+```python
+from zapros.websocket import BinaryMessage, aconnect_ws
+
+async with aconnect_ws("wss://api.example.com/upload") as ws:
+    await ws.send(BinaryMessage(data=b"\x00\x01\x02"))
+```
+
+## Subprotocols
+
+Pass a list of preferred subprotocols. The server picks one and includes it in the handshake response:
+
+```python
+from zapros.websocket import aconnect_ws
+
+async with aconnect_ws(
+    "wss://api.example.com/ws",
+    subprotocols=["graphql-ws", "json"],
+) as ws:
+    ...
+```
+
+## permessage-deflate
+
+Enable the [permessage-deflate](https://datatracker.ietf.org/doc/html/rfc7692) extension by passing `permessage_deflate=True`, or pass a `PerMessageDeflateExtension` to customize the parameters:
+
+```python
+from zapros.websocket import (
+    PerMessageDeflateExtension,
+    aconnect_ws,
+)
+
+async with aconnect_ws(
+    "wss://api.example.com/ws",
+    permessage_deflate=PerMessageDeflateExtension(
+        client_no_context_takeover=True,
+        server_no_context_takeover=True,
+        client_max_window_bits=12,
+        server_max_window_bits=12,
+    ),
+) as ws:
+    ...
+```
+
+## Reusing a client
+
+Pass an existing `AsyncClient` / `Client` to share handlers, headers, cookies, and authentication with the rest of your code:
+
+::: code-group
+
+```python [Async]
+from zapros import AsyncClient
+from zapros.websocket import aconnect_ws
+
+client = AsyncClient(
+    headers={"Authorization": "Bearer token"},
+)
+
+async with aconnect_ws(
+    "wss://api.example.com/ws",
+    client=client,
+) as ws:
+    ...
+```
+
+```python [Sync]
+from zapros import Client
+from zapros.websocket import connect_ws
+
+client = Client(
+    headers={"Authorization": "Bearer token"},
+)
+
+with connect_ws(
+    "wss://api.example.com/ws",
+    client=client,
+) as ws:
+    ...
+```
+
+:::
+
+The handshake is a normal `GET` request, so any handler middleware on the client (auth, cookies, custom headers) participates in it.
+
+## Testing ASGI applications
+
+Because the WebSocket handshake goes through the client's handler stack, an `AsyncClient` configured with [`AsgiHandler`](/asgi) lets you drive your ASGI app's WebSocket endpoints directly — no real network, no separate test server.
+
+```python
+from litestar import Litestar
+from litestar.handlers import websocket_listener
+
+from zapros import AsgiHandler, AsyncClient
+from zapros.websocket import TextMessage, aconnect_ws
+
+
+@websocket_listener("/echo")
+async def echo(data: str) -> str:
+    return data
+
+
+app = Litestar(route_handlers=[echo])
+
+async with AsyncClient(handler=AsgiHandler(app)) as client:
+    async with aconnect_ws(
+        "ws://testserver/echo",
+        client=client,
+    ) as ws:
+        await ws.send(TextMessage(data="hello"))
+
+        match await ws.recv():
+            case TextMessage(data=text):
+                assert text == "hello"
+```
+
+The same `aconnect_ws` API works against the in-process ASGI app exactly as it does against a real server, so test code and production code stay symmetric.
+
+::: tip ASGI WebSocket framing
+The ASGI WebSocket spec only carries text and binary payloads — there is no in-band representation of `Ping` / `Pong` frames. Sending `PingMessage` or `PongMessage` over an ASGI-backed connection is a silent no-op, so heartbeat code written against a real network connection still works under test.
+:::
+
+## Closing
+
+Leaving the `with` / `async with` block closes the connection with code `1000` (normal closure). To send a specific close code or reason, call `close()` explicitly before exiting:
+
+```python
+from zapros.websocket import CloseCode, aconnect_ws
+
+async with aconnect_ws("wss://api.example.com/ws") as ws:
+    await ws.close(
+        code=CloseCode.GOING_AWAY,
+        reason="client shutting down",
+    )
+```
+
+After the connection closes, `ws.close_code` and `ws.close_reason` expose the negotiated close code and reason.
+
+## Error handling
+
+Calling `send` or `recv` on a closed connection raises `ConnectionClosed`. The exception carries the close code and reason, so you can distinguish a clean close from an abnormal one:
+
+```python
+from zapros.websocket import (
+    CloseCode,
+    ConnectionClosed,
+    TextMessage,
+    aconnect_ws,
+)
+
+async with aconnect_ws("wss://api.example.com/ws") as ws:
+    try:
+        while True:
+            await ws.send(TextMessage(data="ping"))
+            await ws.recv()
+    except ConnectionClosed as exc:
+        if exc.code == CloseCode.NORMAL:
+            print("server closed cleanly")
+        else:
+            print(f"closed with {exc.code}: {exc.reason}")
+```
+
+When iterating with `async for` / `for`, a peer-initiated close ends the loop without raising — the loop simply stops at the close frame.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,9 @@ caching = [
 socks = [
     "socksio>=1.0.0",
 ]
+websocket = [
+    "wsproto>=1.2.0",
+]
 
 [dependency-groups]
 dev = [
@@ -68,6 +71,7 @@ dev = [
     "sniffio>=1.3.1",
     "anyio>=4.12.1",
     "uvicorn>=0.38.0",
+    "wsproto>=1.3.2",
 ]
 
 [tool.pytest.ini_options]
@@ -90,6 +94,8 @@ exclude = [
     "tests/test_sync_auth.py",
     "tests/handlers/test_sync_cassette.py",
     "tests/handlers/test_sync_caching.py",
+    "src/zapros/websocket/_sync.py",
+    "tests/websocket/test_sync.py",
 ]
 
 [tool.ruff.lint]

--- a/ry.yml
+++ b/ry.yml
@@ -44,6 +44,13 @@ packages:
       - id: aread
         match: '\baread\b'
         replace: 'read'
+      
+      - id: async-base-websocket
+        match: '\bAsyncBaseWebSocket\b'
+        replace: 'BaseWebSocket'
+      - id: async-websocket
+        match: '\bAsyncWebSocket\b'
+        replace: 'WebSocket'
 
   zapros-internal:
     rules:
@@ -56,8 +63,8 @@ packages:
       - match: '\baconnect\b'
         replace: 'connect'
 
-      - match: '\baconnect_tcp\b'
-        replace: 'connect_tcp'
+      - match: '\baconnect_ws\b'
+        replace: 'connect_ws'
 
       - match: '\basync_next\b'
         replace: 'next'
@@ -244,3 +251,28 @@ targets:
     rules:
       - match: '\btest_async\b'
         replace: 'test_sync'
+
+  - input: src/zapros/websocket/_async.py
+    output: src/zapros/websocket/_sync.py
+    rules:
+      - match: '\bfrom zapros\._compat import AnyLock\b'
+        replace: 'from threading import Lock'
+      - match: '\bfrom zapros\._compat import AnyLock, AnySemaphore\b'
+        replace: 'from threading import Lock, Semaphore'
+      - match: '\bAnyLock\b'
+        replace: 'Lock'
+      - match: '\bAnySemaphore\b'
+        replace: 'Semaphore'
+      - match: '\bfrom zapros\._compat import AnyEvent\b'
+        replace: 'from threading import Event'
+      - match: '\bAnyEvent\b'
+        replace: 'Event'
+  - input: tests/websocket/test_async.py
+    output: tests/websocket/test_sync.py
+    rules:
+      - match: 'from zapros._websocket._async'
+        replace: 'from zapros._websocket._sync'
+      - match: '\bfrom zapros._compat import anysleep\b'
+        replace: 'from time import sleep'
+      - match: '\banysleep\b'
+        replace: 'sleep'

--- a/src/zapros/_compat.py
+++ b/src/zapros/_compat.py
@@ -23,10 +23,6 @@ def in_trio_run() -> bool:
     return trio.lowlevel.in_trio_run()
 
 
-class AnyEventTimeoutError(Exception):
-    """Raised when a timeout occurs while waiting for an AnyEvent."""
-
-
 class AnyEvent:
     """
     An event that can be used in both asyncio and trio contexts.
@@ -50,7 +46,11 @@ class AnyEvent:
     def is_set(self) -> bool:
         return self._event.is_set()
 
-    async def wait(self, timeout: float | None = None) -> None:
+    async def wait(self, timeout: float | None = None) -> bool:
+        """
+        Wait until the event is set. If timeout is provided, wait at most timeout seconds.
+        Returns True if the event is set, False if the timeout was reached.
+        """
 
         if timeout is None:
             await self._event.wait()
@@ -59,12 +59,13 @@ class AnyEvent:
                 with trio.fail_after(timeout):
                     await self._event.wait()
             except trio.TooSlowError:
-                raise AnyEventTimeoutError("Timeout while waiting for event") from None
+                return False
         else:
             try:
                 await asyncio.wait_for(self._event.wait(), timeout)
             except asyncio.TimeoutError:
-                raise AnyEventTimeoutError("Timeout while waiting for event") from None
+                return False
+        return True
 
 
 class AnyLock:

--- a/src/zapros/_handlers/_asgi.py
+++ b/src/zapros/_handlers/_asgi.py
@@ -8,7 +8,7 @@ from urllib.parse import unquote
 
 from typing_extensions import Self
 
-from zapros._compat import AnyEvent, AnyEventTimeoutError, AnyQueue, in_trio_run
+from zapros._compat import AnyEvent, AnyQueue, in_trio_run
 from zapros._constants import DEFAULT_PORTS
 from zapros._errors import AsgiLifespanShutdownTimeoutError, AsgiLifespanStartupTimeoutError
 
@@ -29,6 +29,9 @@ LifespanStatus = Literal["pending", "complete", "failed"]
 LifespanStartupStatus = Literal["pending", "complete", "failed", "not_supported"]
 
 ResponseHeadersAndStatus = tuple[int, list[tuple[str, str]]]
+
+# WebSocket stream lifecycle states.
+WebSocketState = Literal["connecting", "connected", "disconnected"]
 
 
 class AsgiStream(AsyncClosableStream):
@@ -204,6 +207,275 @@ class AsgiStream(AsyncClosableStream):
         await self._send_queue.aclose()
 
 
+class AsgiWebSocketStream:
+    """
+    A bidirectional handle to an ASGI WebSocket connection.
+
+    This object is exposed to upstream code via `Response(context={"handoff": {"_asgi_websocket_stream": ...}})`
+    once the handshake has completed successfully. The application is driven by a background
+    task that:
+      * delivers `websocket.connect` / `websocket.receive` / `websocket.disconnect` events
+        to the app via `receive()`, by reading from `_client_to_app_queue`
+      * collects `websocket.accept` / `websocket.send` / `websocket.close` events from the app
+        via `send()`, by writing to `_app_to_client_queue`
+
+    Upstream usage:
+        await stream.asend(text="hello")
+        msg = await stream.areceive()   # raises
+        await stream.aclose(code=1000, reason="bye")
+    """
+
+    def __init__(
+        self,
+        client_to_app_queue: AnyQueue[dict[str, Any]],
+        app_to_client_queue: AnyQueue[dict[str, Any]],
+        accept_subprotocol: Optional[str],
+        accept_headers: list[tuple[str, str]],
+        asyncio_task: Optional[asyncio.Task[None]] = None,
+    ) -> None:
+        # Queue we put `websocket.receive` / `websocket.disconnect` events into
+        # for the ASGI application to consume.
+        self._client_to_app_queue: AnyQueue[dict[str, Any]] = client_to_app_queue
+
+        # Queue the ASGI application puts `websocket.send` / `websocket.close` events into
+        # for upstream code to consume via `areceive()`.
+        self._app_to_client_queue: AnyQueue[dict[str, Any]] = app_to_client_queue
+
+        # Subprotocol & extra headers chosen by the application during accept;
+        # exposed so upstream code (e.g. a real WS proxy) can mirror them on the
+        # wire when completing the handshake with the actual client.
+        self.accept_subprotocol = accept_subprotocol
+        self.accept_headers = accept_headers
+
+        self._asyncio_task = asyncio_task
+
+        self._state: WebSocketState = "connected"
+
+    @property
+    def state(self) -> WebSocketState:
+        return self._state
+
+    @classmethod
+    async def _create_response_with_stream(
+        cls,
+        app: Any,
+        scope: dict[str, Any],
+        trio_nursery: Optional["trio.Nursery"] = None,
+    ) -> Response:
+        """
+        Drive the ASGI websocket handshake and, once completed, return an
+        HTTP-shaped `Response` that carries the live `AsgiWebSocketStream` in
+        `context["handoff"]["_asgi_websocket_stream"]`.
+
+        On accept: returns a 101 response with the stream in context.
+        On reject (close before accept, or app raised before accept): returns a
+        403 response with no stream in context.
+        """
+        client_to_app_queue = AnyQueue[dict[str, Any]]()
+        app_to_client_queue = AnyQueue[dict[str, Any]]()
+
+        # Fired once the app has either accepted or closed the handshake;
+        # `handshake_result` carries the outcome.
+        handshake_done_event = AnyEvent()
+        handshake_result: dict[str, Any] = {}
+
+        close_was_received = False
+
+        # Pre-load the `websocket.connect` event so the very first
+        # `receive()` call from the app returns it without blocking.
+        await client_to_app_queue.put({"type": "websocket.connect"})
+
+        async def _run() -> None:
+            async def receive() -> dict[str, Any]:
+                msg = await client_to_app_queue.get()
+                logger.debug("ASGI websocket app receive(): %s", msg.get("type"))
+                return msg
+
+            async def send(message: dict[str, Any]) -> None:
+                msg_type = message["type"]
+                logger.debug("ASGI websocket app send(): %s", msg_type)
+                if msg_type == "websocket.accept":
+                    if handshake_done_event.is_set():
+                        # Spec: accept after accept (or after close) is invalid.
+                        raise RuntimeError("websocket.accept sent after handshake already completed")
+                    subprotocol = message.get("subprotocol")
+                    raw_headers: list[tuple[bytes, bytes]] = message.get("headers", []) or []
+                    headers = [(k.decode("ascii"), v.decode("latin-1")) for k, v in raw_headers]
+                    handshake_result["accepted"] = True
+                    handshake_result["subprotocol"] = subprotocol
+                    handshake_result["headers"] = headers
+                    handshake_done_event.set()
+
+                elif msg_type == "websocket.close":
+                    code = message.get("code", 1000)
+                    reason = message.get("reason", "") or ""
+                    if not handshake_done_event.is_set():
+                        # Close before accept = reject; per spec this is HTTP 403.
+                        handshake_result["accepted"] = False
+                        handshake_result["code"] = code
+                        handshake_result["reason"] = reason
+                        handshake_done_event.set()
+                    else:
+                        nonlocal close_was_received
+                        # Close after accept = normal end-of-stream; deliver to consumer.
+                        close_was_received = True
+                        await app_to_client_queue.put(message)
+
+                elif msg_type == "websocket.send":
+                    if not handshake_done_event.is_set():
+                        raise RuntimeError("websocket.send sent before websocket.accept")
+                    await app_to_client_queue.put(message)
+
+                else:
+                    raise RuntimeError(f"Unexpected ASGI websocket message type: {msg_type!r}")
+
+            try:
+                await app(scope, receive, send)
+            except BaseException:
+                # If the app dies before completing the handshake, treat as a
+                # rejection (HTTP 403). If it dies after accept, push a synthetic
+                # close into the consumer queue so `areceive()` raises a clean
+                # disconnect rather than hanging.
+                if not handshake_done_event.is_set():
+                    handshake_result["accepted"] = False
+                    handshake_result["code"] = 1011  # internal error
+                    handshake_result["reason"] = "ASGI application raised before accept"
+                    handshake_done_event.set()
+                elif not close_was_received:
+                    await app_to_client_queue.put(
+                        {"type": "websocket.close", "code": 1011, "reason": "ASGI application raised"}
+                    )
+                return
+
+            # App returned without explicit close. If accept happened, that's an
+            # implicit graceful close; if not, it's a rejection.
+            if not handshake_done_event.is_set():
+                handshake_result["accepted"] = False
+                handshake_result["code"] = 1006
+                handshake_result["reason"] = "ASGI application returned before accept"
+                handshake_done_event.set()
+            elif not close_was_received:
+                await app_to_client_queue.put({"type": "websocket.close", "code": 1000, "reason": ""})
+
+        task: Optional[asyncio.Task[None]] = None
+        if trio_nursery is not None:
+            trio_nursery.start_soon(_run)
+        else:
+            task = asyncio.create_task(_run())
+
+        logger.debug("Waiting for ASGI application to complete websocket handshake...")
+        await handshake_done_event.wait()
+        logger.debug("ASGI websocket handshake completed: %s", handshake_result)
+
+        if not handshake_result.get("accepted"):
+            # Rejected handshake: surface as HTTP 403, no stream handoff.
+            # Cancel the background task — there is no further work for it to do.
+            if task is not None:
+                task.cancel()
+                try:
+                    await task
+                except (asyncio.CancelledError, BaseException):
+                    pass
+            return Response(
+                status=403,
+                headers=Headers([]),
+                content=b"",
+            )
+
+        stream = cls(
+            client_to_app_queue=client_to_app_queue,
+            app_to_client_queue=app_to_client_queue,
+            accept_subprotocol=handshake_result.get("subprotocol"),
+            accept_headers=handshake_result.get("headers", []),
+            asyncio_task=task,
+        )
+
+        # Build the accept-time HTTP response. Status 101 is the on-the-wire
+        # equivalent of a successful WS handshake; upstream code that's
+        # bridging to a real socket can use this together with `accept_headers`
+        # / `accept_subprotocol` to complete the wire handshake.
+        return Response(
+            status=101,
+            headers=Headers(handshake_result.get("headers", [])),
+            content=b"",
+            context={"handoff": {"_asgi_websocket_stream": stream}},
+        )
+
+    async def asend(
+        self,
+        *,
+        text: Optional[str] = None,
+        bytes: Optional[bytes] = None,  # noqa: A002 - matches ASGI spec key name
+    ) -> None:
+        """
+        Send a `websocket.receive` event to the ASGI application. Per spec,
+        exactly one of `text` or `bytes` must be non-None.
+        """
+        if self._state != "connected":
+            raise RuntimeError(f"Cannot send on websocket in state {self._state!r}")
+        if (text is None) == (bytes is None):
+            raise ValueError("Exactly one of `text` or `bytes` must be provided")
+
+        message: dict[str, Any] = {"type": "websocket.receive"}
+        if text is not None:
+            message["text"] = text
+        else:
+            message["bytes"] = bytes
+        await self._client_to_app_queue.put(message)
+
+    async def areceive(self) -> dict[str, Any]:
+        """
+        Read the next event the ASGI application has sent to the client.
+
+        Returns the raw ASGI message dict for `websocket.send` events
+        (`{"type": "websocket.send", "text"/"bytes": ...}`).
+
+        Raises `ConnectionClosed` when the application closes the
+        connection (either via an explicit `websocket.close` or by returning).
+        """
+        from zapros.websocket._errors import ConnectionClosed
+
+        if self._state == "disconnected":
+            raise ConnectionClosed(code=1006, reason="")
+
+        message = await self._app_to_client_queue.get()
+        msg_type = message.get("type")
+
+        if msg_type == "websocket.close":
+            self._state = "disconnected"
+            raise ConnectionClosed(
+                code=message.get("code", 1000),
+                reason=message.get("reason", "") or "",
+            )
+
+        return message
+
+    async def aclose(self, code: int = 1000, reason: str = "") -> None:
+        """
+        Tell the ASGI application that the client has disconnected, then tear
+        down the background task. Idempotent.
+        """
+        if self._state != "disconnected":
+            self._state = "disconnected"
+            # Best-effort: notify the app. If the app has already exited, the
+            # queue put still succeeds — no one will read it, but that's fine.
+            try:
+                await self._client_to_app_queue.put({"type": "websocket.disconnect", "code": code, "reason": reason})
+            except Exception:
+                # Queue may already be closed if the app exited first; ignore.
+                pass
+
+        if self._asyncio_task is not None and not self._asyncio_task.done():
+            self._asyncio_task.cancel()
+            try:
+                await self._asyncio_task
+            except asyncio.CancelledError:
+                pass
+
+        await self._client_to_app_queue.aclose()
+        await self._app_to_client_queue.aclose()
+
+
 class AsgiHandler(AsyncBaseHandler):
     def __init__(
         self,
@@ -250,6 +522,14 @@ class AsgiHandler(AsyncBaseHandler):
 
         self._asyncio_task: asyncio.Task[None] | None = None
 
+    def _is_websocket_request(self, request: Request) -> bool:
+        scheme = request.url.protocol[:-1].lower()
+        if scheme in ("ws", "wss"):
+            return True
+        # Also detect HTTP requests that are upgrading to WebSocket.
+        upgrade = request.headers.get("upgrade", "")
+        return upgrade.lower() == "websocket"
+
     def _build_scope(self, request: Request) -> dict[str, Any]:
         headers = [(k.lower().encode("ascii"), v.encode("latin-1")) for k, v in request.headers.list()]
 
@@ -270,6 +550,42 @@ class AsgiHandler(AsyncBaseHandler):
             "headers": headers,
             "client": self.client,
             "server": (request.url.hostname, server_port),
+        }
+
+        if self.enable_lifespan:
+            scope["state"] = self._lifespan_state.copy()
+
+        return scope
+
+    def _build_websocket_scope(self, request: Request) -> dict[str, Any]:
+        headers = [(k.lower().encode("ascii"), v.encode("latin-1")) for k, v in request.headers.list()]
+
+        # Map http(s) -> ws(s) when caller routed an upgrading HTTP request here.
+        scheme = request.url.protocol[:-1].lower()
+        ws_scheme_map = {"http": "ws", "https": "wss"}
+        scheme = ws_scheme_map.get(scheme, scheme) if scheme not in ("ws", "wss") else scheme
+
+        server_port = request.url.port or DEFAULT_PORTS.get(scheme, 80)
+        raw_path = request.url.pathname.encode("utf-8")
+
+        # Subprotocols come from the Sec-WebSocket-Protocol request header,
+        # comma-separated per RFC 6455.
+        subprotocols_header = request.headers.get("sec-websocket-protocol", "")
+        subprotocols = [p.strip() for p in subprotocols_header.split(",") if p.strip()] if subprotocols_header else []
+
+        scope: dict[str, Any] = {
+            "type": "websocket",
+            "asgi": {"version": "3.0", "spec_version": "2.5"},
+            "http_version": self.http_version,
+            "scheme": scheme,
+            "path": unquote(request.url.pathname) or "/",
+            "raw_path": raw_path or b"/",
+            "query_string": request.url.search[1:].encode("utf-8"),
+            "root_path": self.root_path,
+            "headers": headers,
+            "client": self.client,
+            "server": (request.url.hostname, server_port),
+            "subprotocols": subprotocols,
         }
 
         if self.enable_lifespan:
@@ -331,33 +647,45 @@ class AsgiHandler(AsyncBaseHandler):
             self._lifespan_startup_event.set()
             self._lifespan_startup_status = "not_supported"
 
+    async def _ensure_lifespan_started(self) -> None:
+        """Block until lifespan startup is done (or raise on timeout/failure)."""
+        if not self.enable_lifespan:
+            return
+
+        if self._asyncio_task is None and not in_trio_run():
+            self._asyncio_task = asyncio.create_task(self._run_lifespan())
+
+        logger.debug("Waiting for ASGI application lifespan startup to complete...")
+        was_set = await self._lifespan_startup_event.wait(self.startup_timeout)
+        logger.debug("ASGI application lifespan startup completed with status: %s", self._lifespan_startup_status)
+
+        if not was_set:
+            raise AsgiLifespanStartupTimeoutError(
+                f"ASGI application lifespan startup did not complete within {self.startup_timeout} seconds"
+            )
+
+        if self._lifespan_startup_status == "failed":
+            # Per the specification, if the lifespan startup fails, server should the exit with an error.
+            raise RuntimeError(
+                "ASGI application lifespan startup failed: "
+                f"{self._lifespan_startup_failure_message or 'no message provided'}"
+            )
+
     async def ahandle(self, request: Request) -> Response:
         if in_trio_run() and self._trio_nursery is None:
             raise RuntimeError(
                 "When using `AsgiHandler` with Trio, you must use it as an async "
                 "context manager (i.e. `async with AsgiHandler(...) as handler:`)"
             )
-        if self.enable_lifespan:
-            if self._asyncio_task is None and not in_trio_run():
-                self._asyncio_task = asyncio.create_task(self._run_lifespan())
 
-            try:
-                logger.debug("Waiting for ASGI application lifespan startup to complete...")
-                await self._lifespan_startup_event.wait(self.startup_timeout)
-                logger.debug(
-                    "ASGI application lifespan startup completed with status: %s", self._lifespan_startup_status
-                )
-            except AnyEventTimeoutError:
-                raise AsgiLifespanStartupTimeoutError(
-                    f"ASGI application lifespan startup did not complete within {self.startup_timeout} seconds"
-                )
+        await self._ensure_lifespan_started()
 
-            if self._lifespan_startup_status == "failed":
-                # Per the specification, if the lifespan startup fails, server should the exit with an error.
-                raise RuntimeError(
-                    "ASGI application lifespan startup failed: "
-                    f"{self._lifespan_startup_failure_message or 'no message provided'}"
-                )
+        if self._is_websocket_request(request):
+            return await AsgiWebSocketStream._create_response_with_stream(  # type: ignore[reportPrivateUsage]
+                app=self.app,
+                scope=self._build_websocket_scope(request),
+                trio_nursery=self._trio_nursery,
+            )
 
         assert not isinstance(request.body, Iterator)
         response = await AsgiStream._create_response_with_stream(  # type: ignore[reportPrivateUsage]
@@ -398,15 +726,14 @@ class AsgiHandler(AsyncBaseHandler):
         if not self.enable_lifespan:
             return
 
-        try:
-            logger.debug("Waiting for ASGI application lifespan startup to complete before triggering shutdown...")
-            await self._lifespan_startup_event.wait(self.startup_timeout)
-            logger.debug(
-                "ASGI application lifespan startup completed with status: %s, "
-                "proceeding to trigger shutdown if supported",
-                self._lifespan_startup_status,
-            )
-        except AnyEventTimeoutError:
+        logger.debug("Waiting for ASGI application lifespan startup to complete before triggering shutdown...")
+        was_set = await self._lifespan_startup_event.wait(self.startup_timeout)
+        logger.debug(
+            "ASGI application lifespan startup completed with status: %s, proceeding to trigger shutdown if supported",
+            self._lifespan_startup_status,
+        )
+
+        if not was_set:
             raise AsgiLifespanStartupTimeoutError(
                 f"ASGI application lifespan startup did not complete within {self.startup_timeout} seconds"
             )
@@ -416,14 +743,12 @@ class AsgiHandler(AsyncBaseHandler):
             # Signal the lifespan task to start the shutdown sequence.
             self._lifespan_close_event.set()
 
-            try:
-                logger.debug("Waiting for ASGI application lifespan shutdown to complete...")
-                # Wait for the shutdown sequence to complete (either successfully or with failure).
-                await self._lifespan_shutdown_event.wait(self.shutdown_timeout)
-                logger.debug(
-                    "ASGI application lifespan shutdown completed with status: %s", self._lifespan_shutdown_status
-                )
-            except AnyEventTimeoutError:
+            logger.debug("Waiting for ASGI application lifespan shutdown to complete...")
+            # Wait for the shutdown sequence to complete (either successfully or with failure).
+            was_set = await self._lifespan_shutdown_event.wait(self.shutdown_timeout)
+            logger.debug("ASGI application lifespan shutdown completed with status: %s", self._lifespan_shutdown_status)
+
+            if not was_set:
                 raise AsgiLifespanShutdownTimeoutError(
                     f"ASGI application lifespan shutdown did not complete within {self.shutdown_timeout} seconds"
                 )

--- a/src/zapros/_handlers/_async_std.py
+++ b/src/zapros/_handlers/_async_std.py
@@ -782,11 +782,21 @@ class AsyncStdNetworkHandler(AsyncBaseHandler):
             if status == 101:
                 # We won't be able to reuse this connection, so we can release the pool reservation now.
                 await self._pool.release_reservation(key)
+                # h11 reads in DEFAULT_READ_SIZE chunks, so any bytes the peer sent
+                # immediately after the 101 (e.g. WebSocket frames) are sitting in
+                # h11's buffer rather than on the socket. Hand them to the caller
+                # so it can re-inject them into the upgraded protocol parser.
+                trailing_data, _ = conn.h11.trailing_data
                 return Response(
                     status=status,
                     headers=resp_headers,
                     content=None,
-                    context={"handoff": ResponseHandoffContext(network_stream=conn.stream)},
+                    context={
+                        "handoff": ResponseHandoffContext(
+                            network_stream=conn.stream,
+                            trailing_data=bytes(trailing_data),
+                        )
+                    },
                 )
 
         except BaseException:

--- a/src/zapros/_handlers/_sync_std.py
+++ b/src/zapros/_handlers/_sync_std.py
@@ -780,11 +780,21 @@ class StdNetworkHandler(BaseHandler):
             if status == 101:
                 # We won't be able to reuse this connection, so we can release the pool reservation now.
                 self._pool.release_reservation(key)
+                # h11 reads in DEFAULT_READ_SIZE chunks, so any bytes the peer sent
+                # immediately after the 101 (e.g. WebSocket frames) are sitting in
+                # h11's buffer rather than on the socket. Hand them to the caller
+                # so it can re-inject them into the upgraded protocol parser.
+                trailing_data, _ = conn.h11.trailing_data
                 return Response(
                     status=status,
                     headers=resp_headers,
                     content=None,
-                    context={"handoff": ResponseHandoffContext(network_stream=conn.stream)},
+                    context={
+                        "handoff": ResponseHandoffContext(
+                            network_stream=conn.stream,
+                            trailing_data=bytes(trailing_data),
+                        )
+                    },
                 )
 
         except BaseException:

--- a/src/zapros/_models.py
+++ b/src/zapros/_models.py
@@ -29,6 +29,8 @@ from zapros._multidict import (
 from zapros._utils import get_host_header_value
 
 if TYPE_CHECKING:
+    from zapros._handlers._asgi import AsgiWebSocketStream
+
     from ._multipart import Multipart
 
 
@@ -104,6 +106,8 @@ class ResponseCachingContext(TypedDict, total=False):
 
 class ResponseHandoffContext(TypedDict, total=False):
     network_stream: AsyncBaseNetworkStream | BaseNetworkStream
+    trailing_data: bytes
+    _asgi_websocket_stream: "AsgiWebSocketStream"
 
 
 class ResponseContext(TypedDict, total=False):

--- a/src/zapros/websocket/__init__.py
+++ b/src/zapros/websocket/__init__.py
@@ -1,0 +1,13 @@
+from ._async import AsyncBaseWebSocket as AsyncBaseWebSocket, aconnect_ws as aconnect_ws
+from ._errors import ConnectionClosed as ConnectionClosed, WebsocketError as WebsocketError
+from ._sync import BaseWebSocket as BaseWebSocket, connect_ws as connect_ws
+from ._types import (
+    BinaryMessage as BinaryMessage,
+    CloseCode as CloseCode,
+    CloseMessage as CloseMessage,
+    Message as Message,
+    PerMessageDeflateExtension as PerMessageDeflateExtension,
+    PingMessage as PingMessage,
+    PongMessage as PongMessage,
+    TextMessage as TextMessage,
+)

--- a/src/zapros/websocket/_asgi.py
+++ b/src/zapros/websocket/_asgi.py
@@ -1,0 +1,135 @@
+from collections import deque
+from contextlib import suppress
+from typing import Optional
+
+from typing_extensions import Self
+
+from zapros._compat import AnyEvent, AnyLock
+from zapros._handlers._asgi import AsgiWebSocketStream
+from zapros.websocket._async import AsyncBaseWebSocket
+from zapros.websocket._errors import ConnectionClosed
+
+from ._types import (
+    BinaryMessage,
+    CloseCode,
+    CloseMessage,
+    Message,
+    PingMessage,
+    PongMessage,
+    TextMessage,
+)
+
+
+class AsgiWebSocket(AsyncBaseWebSocket):
+    """
+    AsyncBaseWebSocket implementation backed by an in-process ASGI app.
+
+    Unlike AsyncWebSocket, this does not run wsproto over a byte stream — it
+    talks directly to AsgiWebSocketStream's queues, so the ASGI spec's framing
+    is what we have to honor. The ASGI websocket spec only carries text/bytes
+    payloads via websocket.send / websocket.receive: there is no in-band
+    representation of Ping/Pong, so sending those message types is silently
+    a no-op here.
+    """
+
+    def __init__(self, websocket_stream: AsgiWebSocketStream) -> None:
+        self._asgi_websocket_stream = websocket_stream
+
+        self._read_lock = AnyLock()
+        self._write_lock = AnyLock()
+
+        self._buffer: deque[Message] = deque()
+
+        self.our_close: Optional[CloseMessage] = None
+        self.we_sent_close = AnyEvent()
+
+        self.their_close: Optional[CloseMessage] = None
+        self.they_sent_close = AnyEvent()
+
+    def _preferred_close(self) -> Optional[CloseMessage]:
+        if self.their_close is not None:
+            return self.their_close
+        return self.our_close
+
+    async def send(self, message: Message) -> None:
+        async with self._write_lock:
+            close = self._preferred_close()
+            if close is not None:
+                raise ConnectionClosed(code=close.code, reason=close.reason)
+
+            match message:
+                case TextMessage():
+                    await self._asgi_websocket_stream.asend(text=message.data)
+
+                case BinaryMessage():
+                    await self._asgi_websocket_stream.asend(bytes=message.data)
+
+                case CloseMessage():
+                    self.our_close = message
+                    self.we_sent_close.set()
+                    with suppress(Exception):
+                        await self._asgi_websocket_stream.aclose(
+                            code=message.code,
+                            reason=message.reason or "",
+                        )
+
+                case PingMessage() | PongMessage():
+                    return
+
+    async def recv(self) -> Message:
+        async with self._read_lock:
+            if self._buffer:
+                return self._buffer.popleft()
+
+            if self.their_close is not None:
+                raise ConnectionClosed(
+                    code=self.their_close.code,
+                    reason=self.their_close.reason,
+                )
+
+            try:
+                event = await self._asgi_websocket_stream.areceive()
+            except ConnectionClosed as exc:
+                close = CloseMessage(code=exc.code, reason=exc.reason)
+                self.their_close = close
+                self.they_sent_close.set()
+                return close
+
+            if "text" in event and event["text"] is not None:
+                return TextMessage(data=event["text"])
+
+            if "bytes" in event and event["bytes"] is not None:
+                return BinaryMessage(data=bytes(event["bytes"]))
+
+            raise RuntimeError(f"unexpected ASGI websocket event: {event!r}")
+
+    def __aiter__(self) -> Self:
+        return self
+
+    async def __anext__(self) -> Message:
+        message = await self.recv()
+
+        match message:
+            case CloseMessage():
+                raise StopAsyncIteration()
+            case _:
+                return message
+
+    @property
+    def close_code(self) -> int | None:
+        close = self._preferred_close()
+        return None if close is None else close.code
+
+    @property
+    def close_reason(self) -> str | None:
+        close = self._preferred_close()
+        return None if close is None else close.reason
+
+    async def close(self, code: int = CloseCode.NORMAL, reason: str = "") -> None:
+        async with self._write_lock:
+            if self.our_close is None:
+                self.our_close = CloseMessage(code=code, reason=reason)
+                self.we_sent_close.set()
+
+        with suppress(Exception):
+            await self._asgi_websocket_stream.aclose(code=code, reason=reason)

--- a/src/zapros/websocket/_async.py
+++ b/src/zapros/websocket/_async.py
@@ -1,0 +1,719 @@
+from abc import ABC, abstractmethod
+from collections import deque
+from contextlib import AbstractAsyncContextManager, asynccontextmanager, suppress
+from typing import TYPE_CHECKING, Any, AsyncIterator, Optional
+
+from typing_extensions import Self
+
+from zapros._compat import AnyEvent
+from zapros._constants import DEFAULT_READ_SIZE
+from zapros.websocket._errors import ConnectionClosed
+
+if TYPE_CHECKING:
+    from wsproto import WSConnection
+    from wsproto.connection import ConnectionType
+    from wsproto.events import (
+        AcceptConnection,
+        BytesMessage as WSBytesMessage,
+        CloseConnection,
+        Ping,
+        Pong,
+        Request,
+        TextMessage as WSTextMessage,
+    )
+    from wsproto.extensions import PerMessageDeflate
+else:
+    try:
+        from wsproto import WSConnection
+        from wsproto.connection import ConnectionType
+        from wsproto.events import (
+            AcceptConnection,
+            BytesMessage as WSBytesMessage,
+            CloseConnection,
+            Ping,
+            Pong,
+            Request,
+            TextMessage as WSTextMessage,
+        )
+        from wsproto.extensions import PerMessageDeflate
+    except ImportError:
+        WSConnection = None
+        ConnectionType = None
+        AcceptConnection = None
+        WSBytesMessage = None
+        CloseConnection = None
+        Ping = None
+        Pong = None
+        Request = None
+        WSTextMessage = None
+        PerMessageDeflate = None
+
+from zapros import URL, AsyncBaseNetworkStream, AsyncClient, Headers
+from zapros._compat import AnyLock
+
+from ._types import (
+    BinaryMessage,
+    CloseCode,
+    CloseMessage,
+    Message,
+    PerMessageDeflateExtension,
+    PingMessage,
+    PongMessage,
+    TextMessage,
+)
+
+
+def extract_message_headers(message: bytes) -> Headers:
+    """Extract headers from a wsproto handshake message."""
+    headers = message.split(b"\r\n")[1:]
+    parsed_headers = Headers()
+
+    for header in headers:
+        if not header:
+            break
+        key, value = header.split(b":", 1)
+        parsed_headers[key.strip().decode()] = value.strip().decode()
+
+    return parsed_headers
+
+
+class AsyncBaseWebSocket(ABC):
+    """
+    Base class for WebSocket connections.
+    """
+
+    @abstractmethod
+    async def send(
+        self,
+        message: Message,
+    ) -> None:
+        """
+        Send a message over the WebSocket connection.
+
+        Args:
+            message: The message to send, which can be a TextMessage,
+            BinaryMessage, PingMessage, PongMessage, or CloseMessage.
+        """
+
+    @abstractmethod
+    async def recv(self) -> Message:
+        """
+        Receive a message from the WebSocket connection.
+
+        When called on an open connection, this method will block until a message is received.
+        If the connection is closed, it will raise a `ConnectionClosed` exception.
+        """
+
+    @abstractmethod
+    async def close(self, code: int = CloseCode.NORMAL, reason: str = "") -> None:
+        """
+        Close the WebSocket connection.
+
+        Args:
+            code: The close code to send to the peer. Defaults to 1000 (normal closure).
+            reason: An optional reason for closing the connection.
+        """
+
+    @abstractmethod
+    def __aiter__(self) -> AsyncIterator[Message]:
+        """Return an asynchronous iterator over incoming messages."""
+
+    @property
+    @abstractmethod
+    def close_code(self) -> int | None:
+        """The close code if the connection has been closed, or None if still open."""
+
+    @property
+    @abstractmethod
+    def close_reason(self) -> str | None:
+        """The close reason if the connection has been closed, or None if still open."""
+
+
+class AsyncWebSocket(AsyncBaseWebSocket):
+    def __init__(self, stream: AsyncBaseNetworkStream, *, wsproto_connection: WSConnection) -> None:
+        self._stream = stream
+        self._conn = wsproto_connection
+        self._buffer: deque[Message] = deque()
+
+        # Fragment accumulators.
+        self._text_parts: list[str] = []
+        self._bytes_parts: list[bytes] = []
+
+        # Locking rules:
+        #
+        #   _read_lock:
+        #       Protects recv-side user buffers and fragment accumulators.
+        #
+        #   _conn_lock:
+        #       Protects wsproto's mutable state machine and close-state fields.
+        #       Never hold this while doing stream I/O.
+        #
+        #   _wire_lock:
+        #       Serializes bytes written to the underlying stream.
+        #       This may be held during blocking write_all(), but while it is
+        #       held, neither _read_lock nor _conn_lock is held.
+        #
+        # If _wire_lock and _conn_lock are both needed, acquire:
+        #
+        #       _wire_lock -> _conn_lock
+        #
+        # The read path never acquires _wire_lock while holding _conn_lock.
+        self._read_lock = AnyLock()
+        self._conn_lock = AnyLock()
+        self._wire_lock = AnyLock()
+
+        self.we_sent_close = AnyEvent()
+        self.our_close: Optional[CloseMessage] = None
+
+        self.they_sent_close = AnyEvent()
+        self.their_close: Optional[CloseMessage] = None
+
+        # Control frames generated by the read path.
+        #
+        # The read path may need to generate Pong frames and Close responses,
+        # but it must not write them while holding _read_lock or _conn_lock.
+        # So it appends the already-serialized bytes here. Later, recv(),
+        # send(), or close() flushes them outside those locks.
+        self._pending_control_frames: deque[bytes] = deque()
+
+        # Set when the stream should be closed after all pending control frames
+        # have been flushed. This is used after receiving the peer's close.
+        self._close_after_pending_control = False
+
+    def _preferred_close_locked(self) -> Optional[CloseMessage]:
+        """
+        Caller must hold _conn_lock.
+        """
+        if self.their_close is not None:
+            return self.their_close
+        return self.our_close
+
+    def _mark_their_close_locked(self, code: int, reason: str | None) -> CloseMessage:
+        """
+        Caller must hold _conn_lock.
+        """
+        if self.their_close is None:
+            self.their_close = CloseMessage(code=code, reason=reason)
+            self.they_sent_close.set()
+
+        return self.their_close
+
+    async def _mark_abnormal_close(self, reason: str) -> CloseMessage:
+        async with self._conn_lock:
+            return self._mark_their_close_locked(
+                code=CloseCode.ABNORMAL,
+                reason=reason,
+            )
+
+    async def _mark_write_failed(self) -> None:
+        await self._mark_abnormal_close("websocket write failed")
+
+        with suppress(Exception):
+            await self._stream.close()
+
+    async def _write_frame_to_stream(self, frame: bytes, *, raise_errors: bool) -> bool:
+        """
+        Write one already-serialized frame.
+
+        Caller must hold _wire_lock.
+
+        Caller must not hold _read_lock or _conn_lock.
+        """
+        try:
+            await self._stream.write_all(frame)
+            return True
+        except Exception:
+            await self._mark_write_failed()
+            if raise_errors:
+                raise
+            return False
+
+    async def _flush_pending_control_frames_already_have_wire_lock(
+        self,
+        *,
+        raise_errors: bool,
+    ) -> None:
+        """
+        Flush pending Pong / Close-response frames.
+
+        Caller must hold _wire_lock.
+
+        Caller must not hold _read_lock or _conn_lock.
+        """
+        while True:
+            async with self._conn_lock:
+                if self._pending_control_frames:
+                    frames = list(self._pending_control_frames)
+                    self._pending_control_frames.clear()
+                    close_after = False
+                else:
+                    frames = []
+                    close_after = self._close_after_pending_control
+                    self._close_after_pending_control = False
+
+            for frame in frames:
+                if not await self._write_frame_to_stream(frame, raise_errors=raise_errors):
+                    return
+
+            if close_after:
+                with suppress(Exception):
+                    await self._stream.close()
+                return
+
+            if not frames:
+                return
+
+    async def _flush_pending_control_frames(self, *, raise_errors: bool) -> None:
+        """
+        Flush pending control frames without holding recv or wsproto locks.
+
+        This can still block on write_all(), because this is the no-writer-task
+        version. The important part is that it does not block while holding
+        _read_lock or _conn_lock.
+        """
+        async with self._wire_lock:
+            await self._flush_pending_control_frames_already_have_wire_lock(
+                raise_errors=raise_errors,
+            )
+
+    async def send(self, message: Message) -> None:
+        sent_close = False
+
+        # Reserve the wire first. This preserves byte ordering among public
+        # sends and pending automatic control frames.
+        async with self._wire_lock:
+            # Drain any control frames whose wsproto send() calls happened
+            # before this application send.
+            #
+            # The loop closes the small gap between "pending queue is empty"
+            # and "generate this application frame". We only generate the app
+            # frame while holding _conn_lock and after seeing that no older
+            # pending control frame exists.
+            while True:
+                async with self._conn_lock:
+                    if self._pending_control_frames:
+                        frames = list(self._pending_control_frames)
+                        self._pending_control_frames.clear()
+                        close_after = False
+                        frame = None
+                    elif self._close_after_pending_control:
+                        frames = []
+                        close_after = True
+                        self._close_after_pending_control = False
+                        frame = None
+                    else:
+                        close = self._preferred_close_locked()
+                        if close is not None:
+                            raise ConnectionClosed(
+                                code=close.code,
+                                reason=close.reason,
+                            )
+
+                        match message:
+                            case TextMessage():
+                                frame = self._conn.send(WSTextMessage(data=message.data))
+
+                            case BinaryMessage():
+                                frame = self._conn.send(WSBytesMessage(data=message.data))
+
+                            case PingMessage():
+                                frame = self._conn.send(Ping(payload=message.data))
+
+                            case PongMessage():
+                                frame = self._conn.send(Pong(payload=message.data))
+
+                            case CloseMessage():
+                                frame = self._conn.send(
+                                    CloseConnection(
+                                        code=message.code,
+                                        reason=message.reason,
+                                    )
+                                )
+
+                                # Prevent later application sends as soon as
+                                # the close has been generated in wsproto.
+                                self.our_close = message
+                                sent_close = True
+
+                            case _:
+                                raise TypeError(f"unsupported websocket message type: {type(message)!r}")
+
+                        frames = []
+                        close_after = False
+
+                for pending_frame in frames:
+                    await self._write_frame_to_stream(
+                        pending_frame,
+                        raise_errors=True,
+                    )
+
+                if close_after:
+                    with suppress(Exception):
+                        await self._stream.close()
+                    continue
+
+                if frame is not None:
+                    break
+
+            await self._write_frame_to_stream(frame, raise_errors=True)
+
+            if sent_close:
+                self.we_sent_close.set()
+
+    async def recv(self) -> Message:
+        while True:
+            async with self._read_lock:
+                while not self._buffer:
+                    async with self._conn_lock:
+                        close = self.their_close
+
+                    if close is not None:
+                        raise ConnectionClosed(
+                            code=close.code,
+                            reason=close.reason,
+                        )
+
+                    await self._fill_buffer_locked()
+
+                message = self._buffer.popleft()
+
+            # Flush any automatic Pong / Close-response frames generated while
+            # reading, but do it after releasing both _read_lock and _conn_lock.
+            #
+            # This may still block this recv() call on write_all(), but it no
+            # longer wedges the websocket state machine or prevents another
+            # task from observing close/read state.
+            await self._flush_pending_control_frames(raise_errors=False)
+
+            return message
+
+    async def _fill_buffer_locked(self) -> None:
+        """
+        Fill _buffer with at least one message, or observe connection close.
+
+        Caller must hold _read_lock.
+
+        This method may block in stream.read(), but it never writes to the
+        stream and never waits on _wire_lock.
+        """
+        async with self._conn_lock:
+            self._process_events_locked()
+            close = self.their_close
+
+        if self._buffer or close is not None:
+            if close is not None and not self._buffer:
+                self._buffer.append(close)
+            return
+
+        try:
+            chunk = await self._stream.read(DEFAULT_READ_SIZE)
+        except Exception:
+            close = await self._mark_abnormal_close("websocket read failed")
+            if not self._buffer:
+                self._buffer.append(close)
+            return
+
+        if not chunk:
+            close = await self._mark_abnormal_close("peer closed connection without sending close frame")
+            if not self._buffer:
+                self._buffer.append(close)
+            return
+
+        async with self._conn_lock:
+            self._conn.receive_data(chunk)
+            self._process_events_locked()
+            close = self.their_close
+
+        if close is not None and not self._buffer:
+            self._buffer.append(close)
+
+    def _process_events_locked(self) -> None:
+        """
+        Drain pending wsproto events.
+
+        Caller must hold:
+            _read_lock
+            _conn_lock
+
+        This method may call _conn.send(), because that only mutates wsproto
+        and returns bytes. It must not call stream.write_all().
+        """
+        for event in self._conn.events():
+            match event:
+                case WSTextMessage(data=data, message_finished=finished):
+                    self._text_parts.append(data)
+
+                    if finished:
+                        self._buffer.append(TextMessage(data="".join(self._text_parts)))
+                        self._text_parts.clear()
+
+                case WSBytesMessage(data=data, message_finished=finished):
+                    self._bytes_parts.append(bytes(data))
+
+                    if finished:
+                        self._buffer.append(BinaryMessage(data=b"".join(self._bytes_parts)))
+                        self._bytes_parts.clear()
+
+                case Ping(payload=payload):
+                    payload = bytes(payload)
+                    self._buffer.append(PingMessage(data=payload))
+
+                    # Generate the Pong now while holding _conn_lock, but only
+                    # queue the bytes. The actual write happens later outside
+                    # _read_lock and _conn_lock.
+                    if self.our_close is None and self.their_close is None:
+                        with suppress(Exception):
+                            frame = self._conn.send(Pong(payload=payload))
+                            self._pending_control_frames.append(bytes(frame))
+
+                case Pong(payload=payload):
+                    self._buffer.append(PongMessage(data=bytes(payload)))
+
+                case CloseConnection(code=code, reason=reason):
+                    was_new_close = self.their_close is None
+
+                    close = self._mark_their_close_locked(
+                        code=code,
+                        reason=reason,
+                    )
+
+                    if was_new_close:
+                        self._buffer.append(close)
+
+                    if self.our_close is None:
+                        # Generate the close response under _conn_lock, but do
+                        # not write it here.
+                        with suppress(Exception):
+                            response_frame = self._conn.send(event.response())
+                            self._pending_control_frames.append(bytes(response_frame))
+
+                            self.our_close = CloseMessage(
+                                code=code,
+                                reason=reason,
+                            )
+                            self.we_sent_close.set()
+
+                    # After receiving their close, the transport should be
+                    # closed once our pending close response, if any, is flushed.
+                    self._close_after_pending_control = True
+
+                case _:
+                    pass
+
+    def __aiter__(self) -> Self:
+        return self
+
+    async def __anext__(self) -> Message:
+        message = await self.recv()
+
+        match message:
+            case CloseMessage():
+                raise StopAsyncIteration()
+            case _:
+                return message
+
+    @property
+    def close_code(self) -> int | None:
+        close = self._preferred_close_locked()
+        return None if close is None else close.code
+
+    @property
+    def close_reason(self) -> str | None:
+        close = self._preferred_close_locked()
+        return None if close is None else close.reason
+
+    async def close(self, code: int = CloseCode.NORMAL, reason: str = "") -> None:
+        # Initiate close if we have not already done so.
+        #
+        # This can still block in write_all(), because this is the no-writer-
+        # task version. But send() will not hold _conn_lock or _read_lock
+        # while blocked.
+        async with self._conn_lock:
+            already_sent_close = self.our_close is not None
+
+        if not already_sent_close:
+            try:
+                await self.send(CloseMessage(code=code, reason=reason))
+            except ConnectionClosed:
+                # Already closed by either side.
+                pass
+
+        # Drain until we observe the peer's close. Preserve any normal messages
+        # that arrived before the close frame.
+        if not self.they_sent_close.is_set():
+            saved_messages: deque[Message] = deque()
+
+            async with self._read_lock:
+                try:
+                    while not self.they_sent_close.is_set():
+                        if self._buffer:
+                            saved_messages.append(self._buffer.popleft())
+                            continue
+
+                        await self._fill_buffer_locked()
+
+                finally:
+                    while saved_messages:
+                        self._buffer.appendleft(saved_messages.pop())
+
+        # If reading the peer's close generated a close response, flush it now,
+        # outside _read_lock and _conn_lock.
+        await self._flush_pending_control_frames(raise_errors=False)
+
+        with suppress(Exception):
+            await self._stream.close()
+
+
+class aconnect_ws:
+    """Connect to a WebSocket server.
+
+    Usage::
+
+        async with aconnect_ws("wss://example.com/ws") as ws:
+            await ws.send("hello")
+
+            match await ws.recv():
+                case TextMessage(data=data):
+                    print(f"Received text message: {data}")
+                case BinaryMessage(data=data):
+                    print(f"Received binary message: {data}")
+                case _:
+                    print("Received some other kind of message")
+
+    Args:
+        url:
+            The WebSocket URL to connect to. May be provided as a string
+            or ``URL`` instance.
+
+        client:
+            Optional ``AsyncClient`` to use for the HTTP handshake. If not
+            provided, a new client will be created internally.
+
+        subprotocols:
+            Optional list of WebSocket subprotocols to include in the
+            handshake.
+
+        permessage_deflate:
+            Enable or configure the ``permessage-deflate`` WebSocket
+            extension. May be set to ``True`` to enable with default
+            settings, ``False`` to disable, or an instance of
+            ``PerMessageDeflateExtension`` to customize parameters such
+            as context takeover and window sizes.
+    """
+
+    def __init__(
+        self,
+        url: URL | str,
+        *,
+        client: AsyncClient | None = None,
+        subprotocols: list[str] | None = None,
+        permessage_deflate: bool | PerMessageDeflateExtension = False,
+    ) -> None:
+        if WSConnection is None:  # type: ignore[reportUnnecessaryComparison]
+            raise RuntimeError(
+                "wsproto is required for WebSocket support; install with `pip install zapros[websocket]`"
+            )
+
+        self._url = URL(url) if isinstance(url, str) else url
+        self._client = client
+        self._subprotocols = subprotocols
+
+        if permessage_deflate is True:
+            self._permessage_deflate = PerMessageDeflateExtension()
+        elif permessage_deflate is False:
+            self._permessage_deflate = None
+        else:
+            self._permessage_deflate = permessage_deflate
+
+        self._cm: AbstractAsyncContextManager[AsyncBaseWebSocket] | None = None
+
+    @asynccontextmanager
+    async def _connect_once(self) -> AsyncIterator[AsyncBaseWebSocket]:
+        host = self._url.host
+        path = self._url.pathname + self._url.search
+
+        conn = WSConnection(ConnectionType.CLIENT)
+        client = self._client or AsyncClient()
+
+        data_to_send = conn.send(
+            Request(
+                host=host,
+                target=path,
+                subprotocols=self._subprotocols or [],
+                extensions=[
+                    PerMessageDeflate(
+                        client_no_context_takeover=self._permessage_deflate.client_no_context_takeover,
+                        server_no_context_takeover=self._permessage_deflate.server_no_context_takeover,
+                        client_max_window_bits=self._permessage_deflate.client_max_window_bits,
+                        server_max_window_bits=self._permessage_deflate.server_max_window_bits,
+                    )
+                ]
+                if self._permessage_deflate
+                else [],
+            ),
+        )
+
+        # wsproto gives us the raw bytes to send for the handshake request,
+        # but we need to extract the headers to pass to AsyncClient.
+        request_headers = extract_message_headers(data_to_send)
+
+        async with client.stream("GET", self._url, headers=request_headers) as real_response:
+            if real_response.status != 101:
+                raise RuntimeError(
+                    f"WebSocket handshake failed: expected 101 Switching Protocols, got {real_response.status}"
+                )
+
+            handoff = real_response.context.get("handoff", {})
+
+            ws: AsyncBaseWebSocket
+            if websocket_stream := handoff.get("_asgi_websocket_stream"):  # no-op for synchronous path
+                from zapros.websocket._asgi import AsgiWebSocket
+
+                # ASGI path: the ASGI websocket protocol already validated the
+                # handshake at the application layer, so wsproto's HTTP-level
+                # validation does not apply. Skip the conn.receive_data() step
+                # and hand the message-level stream straight to AsgiWebSocket.
+                ws = AsgiWebSocket(websocket_stream)  # type: ignore[reportAssignmentType]
+            else:
+                conn.receive_data(
+                    (
+                        "HTTP/1.1 101 Switching Protocols\r\n"
+                        + "\r\n".join(f"{k}: {v}" for k, v in real_response.headers.items())
+                        + "\r\n\r\n"
+                    ).encode()
+                )
+
+                for event in conn.events():
+                    if isinstance(event, AcceptConnection):
+                        break
+                else:
+                    raise RuntimeError("WebSocket handshake failed")
+
+                network_stream = handoff.get("network_stream")
+                if network_stream is None:
+                    raise RuntimeError("WebSocket handshake failed: no network stream in response context")
+
+                # The HTTP layer reads in 64 KB chunks, so any WebSocket frames the
+                # server sent immediately after the 101 (e.g. an early close) end
+                # up buffered in h11 instead of on the stream. Re-inject them into
+                # wsproto here so AsyncWebSocket sees them on the first recv.
+                trailing_data = handoff.get("trailing_data") or b""
+                if trailing_data:
+                    conn.receive_data(trailing_data)
+
+                assert isinstance(network_stream, AsyncBaseNetworkStream)
+                ws = AsyncWebSocket(network_stream, wsproto_connection=conn)
+
+            try:
+                yield ws
+            finally:
+                await ws.close()
+
+    async def __aenter__(self) -> AsyncBaseWebSocket:
+        self._cm = self._connect_once()
+        return await self._cm.__aenter__()
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        cm, self._cm = self._cm, None
+        if cm is not None:
+            await cm.__aexit__(exc_type, exc, tb)

--- a/src/zapros/websocket/_errors.py
+++ b/src/zapros/websocket/_errors.py
@@ -1,0 +1,23 @@
+from zapros._errors import ZaprosError
+from zapros.websocket._types import CloseCode
+
+
+class WebsocketError(ZaprosError):
+    """Base class for all WebSocket errors."""
+
+    pass
+
+
+class ConnectionClosed(WebsocketError):
+    """Raised when an event is requested on a closed connection."""
+
+    def __init__(
+        self,
+        code: CloseCode | int,
+        reason: str | None = None,
+    ):
+        self.code = code
+        self.reason = reason
+        super().__init__(
+            f"WebSocket connection closed with code {code}" + (f" and reason: {reason!r}" if reason else "")
+        )

--- a/src/zapros/websocket/_sync.py
+++ b/src/zapros/websocket/_sync.py
@@ -1,0 +1,719 @@
+from abc import ABC, abstractmethod
+from collections import deque
+from contextlib import AbstractContextManager, contextmanager, suppress
+from typing import TYPE_CHECKING, Any, Iterator, Optional
+
+from typing_extensions import Self
+
+from threading import Event
+from zapros._constants import DEFAULT_READ_SIZE
+from zapros.websocket._errors import ConnectionClosed
+
+if TYPE_CHECKING:
+    from wsproto import WSConnection
+    from wsproto.connection import ConnectionType
+    from wsproto.events import (
+        AcceptConnection,
+        BytesMessage as WSBytesMessage,
+        CloseConnection,
+        Ping,
+        Pong,
+        Request,
+        TextMessage as WSTextMessage,
+    )
+    from wsproto.extensions import PerMessageDeflate
+else:
+    try:
+        from wsproto import WSConnection
+        from wsproto.connection import ConnectionType
+        from wsproto.events import (
+            AcceptConnection,
+            BytesMessage as WSBytesMessage,
+            CloseConnection,
+            Ping,
+            Pong,
+            Request,
+            TextMessage as WSTextMessage,
+        )
+        from wsproto.extensions import PerMessageDeflate
+    except ImportError:
+        WSConnection = None
+        ConnectionType = None
+        AcceptConnection = None
+        WSBytesMessage = None
+        CloseConnection = None
+        Ping = None
+        Pong = None
+        Request = None
+        WSTextMessage = None
+        PerMessageDeflate = None
+
+from zapros import URL, BaseNetworkStream, Client, Headers
+from threading import Lock
+
+from ._types import (
+    BinaryMessage,
+    CloseCode,
+    CloseMessage,
+    Message,
+    PerMessageDeflateExtension,
+    PingMessage,
+    PongMessage,
+    TextMessage,
+)
+
+
+def extract_message_headers(message: bytes) -> Headers:
+    """Extract headers from a wsproto handshake message."""
+    headers = message.split(b"\r\n")[1:]
+    parsed_headers = Headers()
+
+    for header in headers:
+        if not header:
+            break
+        key, value = header.split(b":", 1)
+        parsed_headers[key.strip().decode()] = value.strip().decode()
+
+    return parsed_headers
+
+
+class BaseWebSocket(ABC):
+    """
+    Base class for WebSocket connections.
+    """
+
+    @abstractmethod
+    def send(
+        self,
+        message: Message,
+    ) -> None:
+        """
+        Send a message over the WebSocket connection.
+
+        Args:
+            message: The message to send, which can be a TextMessage,
+            BinaryMessage, PingMessage, PongMessage, or CloseMessage.
+        """
+
+    @abstractmethod
+    def recv(self) -> Message:
+        """
+        Receive a message from the WebSocket connection.
+
+        When called on an open connection, this method will block until a message is received.
+        If the connection is closed, it will raise a `ConnectionClosed` exception.
+        """
+
+    @abstractmethod
+    def close(self, code: int = CloseCode.NORMAL, reason: str = "") -> None:
+        """
+        Close the WebSocket connection.
+
+        Args:
+            code: The close code to send to the peer. Defaults to 1000 (normal closure).
+            reason: An optional reason for closing the connection.
+        """
+
+    @abstractmethod
+    def __iter__(self) -> Iterator[Message]:
+        """Return an asynchronous iterator over incoming messages."""
+
+    @property
+    @abstractmethod
+    def close_code(self) -> int | None:
+        """The close code if the connection has been closed, or None if still open."""
+
+    @property
+    @abstractmethod
+    def close_reason(self) -> str | None:
+        """The close reason if the connection has been closed, or None if still open."""
+
+
+class WebSocket(BaseWebSocket):
+    def __init__(self, stream: BaseNetworkStream, *, wsproto_connection: WSConnection) -> None:
+        self._stream = stream
+        self._conn = wsproto_connection
+        self._buffer: deque[Message] = deque()
+
+        # Fragment accumulators.
+        self._text_parts: list[str] = []
+        self._bytes_parts: list[bytes] = []
+
+        # Locking rules:
+        #
+        #   _read_lock:
+        #       Protects recv-side user buffers and fragment accumulators.
+        #
+        #   _conn_lock:
+        #       Protects wsproto's mutable state machine and close-state fields.
+        #       Never hold this while doing stream I/O.
+        #
+        #   _wire_lock:
+        #       Serializes bytes written to the underlying stream.
+        #       This may be held during blocking write_all(), but while it is
+        #       held, neither _read_lock nor _conn_lock is held.
+        #
+        # If _wire_lock and _conn_lock are both needed, acquire:
+        #
+        #       _wire_lock -> _conn_lock
+        #
+        # The read path never acquires _wire_lock while holding _conn_lock.
+        self._read_lock = Lock()
+        self._conn_lock = Lock()
+        self._wire_lock = Lock()
+
+        self.we_sent_close = Event()
+        self.our_close: Optional[CloseMessage] = None
+
+        self.they_sent_close = Event()
+        self.their_close: Optional[CloseMessage] = None
+
+        # Control frames generated by the read path.
+        #
+        # The read path may need to generate Pong frames and Close responses,
+        # but it must not write them while holding _read_lock or _conn_lock.
+        # So it appends the already-serialized bytes here. Later, recv(),
+        # send(), or close() flushes them outside those locks.
+        self._pending_control_frames: deque[bytes] = deque()
+
+        # Set when the stream should be closed after all pending control frames
+        # have been flushed. This is used after receiving the peer's close.
+        self._close_after_pending_control = False
+
+    def _preferred_close_locked(self) -> Optional[CloseMessage]:
+        """
+        Caller must hold _conn_lock.
+        """
+        if self.their_close is not None:
+            return self.their_close
+        return self.our_close
+
+    def _mark_their_close_locked(self, code: int, reason: str | None) -> CloseMessage:
+        """
+        Caller must hold _conn_lock.
+        """
+        if self.their_close is None:
+            self.their_close = CloseMessage(code=code, reason=reason)
+            self.they_sent_close.set()
+
+        return self.their_close
+
+    def _mark_abnormal_close(self, reason: str) -> CloseMessage:
+        with self._conn_lock:
+            return self._mark_their_close_locked(
+                code=CloseCode.ABNORMAL,
+                reason=reason,
+            )
+
+    def _mark_write_failed(self) -> None:
+        self._mark_abnormal_close("websocket write failed")
+
+        with suppress(Exception):
+            self._stream.close()
+
+    def _write_frame_to_stream(self, frame: bytes, *, raise_errors: bool) -> bool:
+        """
+        Write one already-serialized frame.
+
+        Caller must hold _wire_lock.
+
+        Caller must not hold _read_lock or _conn_lock.
+        """
+        try:
+            self._stream.write_all(frame)
+            return True
+        except Exception:
+            self._mark_write_failed()
+            if raise_errors:
+                raise
+            return False
+
+    def _flush_pending_control_frames_already_have_wire_lock(
+        self,
+        *,
+        raise_errors: bool,
+    ) -> None:
+        """
+        Flush pending Pong / Close-response frames.
+
+        Caller must hold _wire_lock.
+
+        Caller must not hold _read_lock or _conn_lock.
+        """
+        while True:
+            with self._conn_lock:
+                if self._pending_control_frames:
+                    frames = list(self._pending_control_frames)
+                    self._pending_control_frames.clear()
+                    close_after = False
+                else:
+                    frames = []
+                    close_after = self._close_after_pending_control
+                    self._close_after_pending_control = False
+
+            for frame in frames:
+                if not self._write_frame_to_stream(frame, raise_errors=raise_errors):
+                    return
+
+            if close_after:
+                with suppress(Exception):
+                    self._stream.close()
+                return
+
+            if not frames:
+                return
+
+    def _flush_pending_control_frames(self, *, raise_errors: bool) -> None:
+        """
+        Flush pending control frames without holding recv or wsproto locks.
+
+        This can still block on write_all(), because this is the no-writer-task
+        version. The important part is that it does not block while holding
+        _read_lock or _conn_lock.
+        """
+        with self._wire_lock:
+            self._flush_pending_control_frames_already_have_wire_lock(
+                raise_errors=raise_errors,
+            )
+
+    def send(self, message: Message) -> None:
+        sent_close = False
+
+        # Reserve the wire first. This preserves byte ordering among public
+        # sends and pending automatic control frames.
+        with self._wire_lock:
+            # Drain any control frames whose wsproto send() calls happened
+            # before this application send.
+            #
+            # The loop closes the small gap between "pending queue is empty"
+            # and "generate this application frame". We only generate the app
+            # frame while holding _conn_lock and after seeing that no older
+            # pending control frame exists.
+            while True:
+                with self._conn_lock:
+                    if self._pending_control_frames:
+                        frames = list(self._pending_control_frames)
+                        self._pending_control_frames.clear()
+                        close_after = False
+                        frame = None
+                    elif self._close_after_pending_control:
+                        frames = []
+                        close_after = True
+                        self._close_after_pending_control = False
+                        frame = None
+                    else:
+                        close = self._preferred_close_locked()
+                        if close is not None:
+                            raise ConnectionClosed(
+                                code=close.code,
+                                reason=close.reason,
+                            )
+
+                        match message:
+                            case TextMessage():
+                                frame = self._conn.send(WSTextMessage(data=message.data))
+
+                            case BinaryMessage():
+                                frame = self._conn.send(WSBytesMessage(data=message.data))
+
+                            case PingMessage():
+                                frame = self._conn.send(Ping(payload=message.data))
+
+                            case PongMessage():
+                                frame = self._conn.send(Pong(payload=message.data))
+
+                            case CloseMessage():
+                                frame = self._conn.send(
+                                    CloseConnection(
+                                        code=message.code,
+                                        reason=message.reason,
+                                    )
+                                )
+
+                                # Prevent later application sends as soon as
+                                # the close has been generated in wsproto.
+                                self.our_close = message
+                                sent_close = True
+
+                            case _:
+                                raise TypeError(f"unsupported websocket message type: {type(message)!r}")
+
+                        frames = []
+                        close_after = False
+
+                for pending_frame in frames:
+                    self._write_frame_to_stream(
+                        pending_frame,
+                        raise_errors=True,
+                    )
+
+                if close_after:
+                    with suppress(Exception):
+                        self._stream.close()
+                    continue
+
+                if frame is not None:
+                    break
+
+            self._write_frame_to_stream(frame, raise_errors=True)
+
+            if sent_close:
+                self.we_sent_close.set()
+
+    def recv(self) -> Message:
+        while True:
+            with self._read_lock:
+                while not self._buffer:
+                    with self._conn_lock:
+                        close = self.their_close
+
+                    if close is not None:
+                        raise ConnectionClosed(
+                            code=close.code,
+                            reason=close.reason,
+                        )
+
+                    self._fill_buffer_locked()
+
+                message = self._buffer.popleft()
+
+            # Flush any automatic Pong / Close-response frames generated while
+            # reading, but do it after releasing both _read_lock and _conn_lock.
+            #
+            # This may still block this recv() call on write_all(), but it no
+            # longer wedges the websocket state machine or prevents another
+            # task from observing close/read state.
+            self._flush_pending_control_frames(raise_errors=False)
+
+            return message
+
+    def _fill_buffer_locked(self) -> None:
+        """
+        Fill _buffer with at least one message, or observe connection close.
+
+        Caller must hold _read_lock.
+
+        This method may block in stream.read(), but it never writes to the
+        stream and never waits on _wire_lock.
+        """
+        with self._conn_lock:
+            self._process_events_locked()
+            close = self.their_close
+
+        if self._buffer or close is not None:
+            if close is not None and not self._buffer:
+                self._buffer.append(close)
+            return
+
+        try:
+            chunk = self._stream.read(DEFAULT_READ_SIZE)
+        except Exception:
+            close = self._mark_abnormal_close("websocket read failed")
+            if not self._buffer:
+                self._buffer.append(close)
+            return
+
+        if not chunk:
+            close = self._mark_abnormal_close("peer closed connection without sending close frame")
+            if not self._buffer:
+                self._buffer.append(close)
+            return
+
+        with self._conn_lock:
+            self._conn.receive_data(chunk)
+            self._process_events_locked()
+            close = self.their_close
+
+        if close is not None and not self._buffer:
+            self._buffer.append(close)
+
+    def _process_events_locked(self) -> None:
+        """
+        Drain pending wsproto events.
+
+        Caller must hold:
+            _read_lock
+            _conn_lock
+
+        This method may call _conn.send(), because that only mutates wsproto
+        and returns bytes. It must not call stream.write_all().
+        """
+        for event in self._conn.events():
+            match event:
+                case WSTextMessage(data=data, message_finished=finished):
+                    self._text_parts.append(data)
+
+                    if finished:
+                        self._buffer.append(TextMessage(data="".join(self._text_parts)))
+                        self._text_parts.clear()
+
+                case WSBytesMessage(data=data, message_finished=finished):
+                    self._bytes_parts.append(bytes(data))
+
+                    if finished:
+                        self._buffer.append(BinaryMessage(data=b"".join(self._bytes_parts)))
+                        self._bytes_parts.clear()
+
+                case Ping(payload=payload):
+                    payload = bytes(payload)
+                    self._buffer.append(PingMessage(data=payload))
+
+                    # Generate the Pong now while holding _conn_lock, but only
+                    # queue the bytes. The actual write happens later outside
+                    # _read_lock and _conn_lock.
+                    if self.our_close is None and self.their_close is None:
+                        with suppress(Exception):
+                            frame = self._conn.send(Pong(payload=payload))
+                            self._pending_control_frames.append(bytes(frame))
+
+                case Pong(payload=payload):
+                    self._buffer.append(PongMessage(data=bytes(payload)))
+
+                case CloseConnection(code=code, reason=reason):
+                    was_new_close = self.their_close is None
+
+                    close = self._mark_their_close_locked(
+                        code=code,
+                        reason=reason,
+                    )
+
+                    if was_new_close:
+                        self._buffer.append(close)
+
+                    if self.our_close is None:
+                        # Generate the close response under _conn_lock, but do
+                        # not write it here.
+                        with suppress(Exception):
+                            response_frame = self._conn.send(event.response())
+                            self._pending_control_frames.append(bytes(response_frame))
+
+                            self.our_close = CloseMessage(
+                                code=code,
+                                reason=reason,
+                            )
+                            self.we_sent_close.set()
+
+                    # After receiving their close, the transport should be
+                    # closed once our pending close response, if any, is flushed.
+                    self._close_after_pending_control = True
+
+                case _:
+                    pass
+
+    def __iter__(self) -> Self:
+        return self
+
+    def __next__(self) -> Message:
+        message = self.recv()
+
+        match message:
+            case CloseMessage():
+                raise StopIteration()
+            case _:
+                return message
+
+    @property
+    def close_code(self) -> int | None:
+        close = self._preferred_close_locked()
+        return None if close is None else close.code
+
+    @property
+    def close_reason(self) -> str | None:
+        close = self._preferred_close_locked()
+        return None if close is None else close.reason
+
+    def close(self, code: int = CloseCode.NORMAL, reason: str = "") -> None:
+        # Initiate close if we have not already done so.
+        #
+        # This can still block in write_all(), because this is the no-writer-
+        # task version. But send() will not hold _conn_lock or _read_lock
+        # while blocked.
+        with self._conn_lock:
+            already_sent_close = self.our_close is not None
+
+        if not already_sent_close:
+            try:
+                self.send(CloseMessage(code=code, reason=reason))
+            except ConnectionClosed:
+                # Already closed by either side.
+                pass
+
+        # Drain until we observe the peer's close. Preserve any normal messages
+        # that arrived before the close frame.
+        if not self.they_sent_close.is_set():
+            saved_messages: deque[Message] = deque()
+
+            with self._read_lock:
+                try:
+                    while not self.they_sent_close.is_set():
+                        if self._buffer:
+                            saved_messages.append(self._buffer.popleft())
+                            continue
+
+                        self._fill_buffer_locked()
+
+                finally:
+                    while saved_messages:
+                        self._buffer.appendleft(saved_messages.pop())
+
+        # If reading the peer's close generated a close response, flush it now,
+        # outside _read_lock and _conn_lock.
+        self._flush_pending_control_frames(raise_errors=False)
+
+        with suppress(Exception):
+            self._stream.close()
+
+
+class connect_ws:
+    """Connect to a WebSocket server.
+
+    Usage::
+
+        with connect_ws("wss://example.com/ws") as ws:
+            ws.send("hello")
+
+            match ws.recv():
+                case TextMessage(data=data):
+                    print(f"Received text message: {data}")
+                case BinaryMessage(data=data):
+                    print(f"Received binary message: {data}")
+                case _:
+                    print("Received some other kind of message")
+
+    Args:
+        url:
+            The WebSocket URL to connect to. May be provided as a string
+            or ``URL`` instance.
+
+        client:
+            Optional ``Client`` to use for the HTTP handshake. If not
+            provided, a new client will be created internally.
+
+        subprotocols:
+            Optional list of WebSocket subprotocols to include in the
+            handshake.
+
+        permessage_deflate:
+            Enable or configure the ``permessage-deflate`` WebSocket
+            extension. May be set to ``True`` to enable with default
+            settings, ``False`` to disable, or an instance of
+            ``PerMessageDeflateExtension`` to customize parameters such
+            as context takeover and window sizes.
+    """
+
+    def __init__(
+        self,
+        url: URL | str,
+        *,
+        client: Client | None = None,
+        subprotocols: list[str] | None = None,
+        permessage_deflate: bool | PerMessageDeflateExtension = False,
+    ) -> None:
+        if WSConnection is None:  # type: ignore[reportUnnecessaryComparison]
+            raise RuntimeError(
+                "wsproto is required for WebSocket support; install with `pip install zapros[websocket]`"
+            )
+
+        self._url = URL(url) if isinstance(url, str) else url
+        self._client = client
+        self._subprotocols = subprotocols
+
+        if permessage_deflate is True:
+            self._permessage_deflate = PerMessageDeflateExtension()
+        elif permessage_deflate is False:
+            self._permessage_deflate = None
+        else:
+            self._permessage_deflate = permessage_deflate
+
+        self._cm: AbstractContextManager[BaseWebSocket] | None = None
+
+    @contextmanager
+    def _connect_once(self) -> Iterator[BaseWebSocket]:
+        host = self._url.host
+        path = self._url.pathname + self._url.search
+
+        conn = WSConnection(ConnectionType.CLIENT)
+        client = self._client or Client()
+
+        data_to_send = conn.send(
+            Request(
+                host=host,
+                target=path,
+                subprotocols=self._subprotocols or [],
+                extensions=[
+                    PerMessageDeflate(
+                        client_no_context_takeover=self._permessage_deflate.client_no_context_takeover,
+                        server_no_context_takeover=self._permessage_deflate.server_no_context_takeover,
+                        client_max_window_bits=self._permessage_deflate.client_max_window_bits,
+                        server_max_window_bits=self._permessage_deflate.server_max_window_bits,
+                    )
+                ]
+                if self._permessage_deflate
+                else [],
+            ),
+        )
+
+        # wsproto gives us the raw bytes to send for the handshake request,
+        # but we need to extract the headers to pass to Client.
+        request_headers = extract_message_headers(data_to_send)
+
+        with client.stream("GET", self._url, headers=request_headers) as real_response:
+            if real_response.status != 101:
+                raise RuntimeError(
+                    f"WebSocket handshake failed: expected 101 Switching Protocols, got {real_response.status}"
+                )
+
+            handoff = real_response.context.get("handoff", {})
+
+            ws: BaseWebSocket
+            if websocket_stream := handoff.get("_asgi_websocket_stream"):  # no-op for synchronous path
+                from zapros.websocket._asgi import AsgiWebSocket
+
+                # ASGI path: the ASGI websocket protocol already validated the
+                # handshake at the application layer, so wsproto's HTTP-level
+                # validation does not apply. Skip the conn.receive_data() step
+                # and hand the message-level stream straight to AsgiWebSocket.
+                ws = AsgiWebSocket(websocket_stream)  # type: ignore[reportAssignmentType]
+            else:
+                conn.receive_data(
+                    (
+                        "HTTP/1.1 101 Switching Protocols\r\n"
+                        + "\r\n".join(f"{k}: {v}" for k, v in real_response.headers.items())
+                        + "\r\n\r\n"
+                    ).encode()
+                )
+
+                for event in conn.events():
+                    if isinstance(event, AcceptConnection):
+                        break
+                else:
+                    raise RuntimeError("WebSocket handshake failed")
+
+                network_stream = handoff.get("network_stream")
+                if network_stream is None:
+                    raise RuntimeError("WebSocket handshake failed: no network stream in response context")
+
+                # The HTTP layer reads in 64 KB chunks, so any WebSocket frames the
+                # server sent immediately after the 101 (e.g. an early close) end
+                # up buffered in h11 instead of on the stream. Re-inject them into
+                # wsproto here so WebSocket sees them on the first recv.
+                trailing_data = handoff.get("trailing_data") or b""
+                if trailing_data:
+                    conn.receive_data(trailing_data)
+
+                assert isinstance(network_stream, BaseNetworkStream)
+                ws = WebSocket(network_stream, wsproto_connection=conn)
+
+            try:
+                yield ws
+            finally:
+                ws.close()
+
+    def __enter__(self) -> BaseWebSocket:
+        self._cm = self._connect_once()
+        return self._cm.__enter__()
+
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        cm, self._cm = self._cm, None
+        if cm is not None:
+            cm.__exit__(exc_type, exc, tb)

--- a/src/zapros/websocket/_types.py
+++ b/src/zapros/websocket/_types.py
@@ -1,0 +1,89 @@
+from dataclasses import dataclass
+from enum import IntEnum
+from typing import Literal
+
+
+class CloseCode(IntEnum):
+    NORMAL = 1000
+    """Normal closure: the purpose of the connection has been fulfilled."""
+
+    GOING_AWAY = 1001
+    """Endpoint is going away (e.g. client navigating away, app exiting)."""
+
+    PROTOCOL_ERROR = 1002
+    """Peer violated the WebSocket protocol."""
+
+    UNSUPPORTED_DATA = 1003
+    """Peer sent a type of data this endpoint cannot accept
+    (e.g. a binary message to a text-only endpoint)."""
+
+    ABNORMAL = 1006
+    """Reserved. MUST NOT be sent on the wire. Used locally to indicate the
+    connection closed without a proper close frame."""
+
+    INVALID_FRAME_PAYLOAD_DATA = 1007
+    """Peer sent message data inconsistent with the message type
+    (e.g. non-UTF-8 bytes inside a text message)."""
+
+    POLICY_VIOLATION = 1008
+    """Peer sent a message that violates this endpoint's policy. Generic code
+    when no more specific code applies."""
+
+    MESSAGE_TOO_BIG = 1009
+    """Peer sent a message too big for this endpoint to process."""
+
+
+@dataclass(frozen=True, slots=True)
+class TextMessage:
+    data: str
+    kind: Literal["text"] = "text"
+
+
+@dataclass(frozen=True, slots=True)
+class BinaryMessage:
+    data: bytes
+    kind: Literal["binary"] = "binary"
+
+
+@dataclass(frozen=True, slots=True)
+class PingMessage:
+    data: bytes = b""
+    kind: Literal["ping"] = "ping"
+
+
+@dataclass(frozen=True, slots=True)
+class PongMessage:
+    data: bytes = b""
+    kind: Literal["pong"] = "pong"
+
+
+@dataclass(frozen=True, slots=True)
+class CloseMessage:
+    """A close frame received from the peer.
+
+    Receiving this does NOT mean the connection is unusable yet — the underlying
+    transport may still be open until `close()` is called. Mirrors the behavior of
+    reqwest-websocket's `Message::Close` variant: the close is surfaced as a
+    regular stream item, and iteration terminates naturally afterwards.
+    """
+
+    code: int = CloseCode.NORMAL
+    reason: str | None = None
+    kind: Literal["close"] = "close"
+
+
+# Tagged union — discriminate via `kind` or with `isinstance` / `match`.
+Message = TextMessage | BinaryMessage | PingMessage | PongMessage | CloseMessage
+
+
+@dataclass(frozen=True, slots=True)
+class PerMessageDeflateExtension:
+    """Represents the negotiated parameters of the permessage-deflate extension.
+
+    This is only relevant if the extension was negotiated during the handshake.
+    """
+
+    client_no_context_takeover: bool = False
+    server_no_context_takeover: bool = False
+    client_max_window_bits: int = 15
+    server_max_window_bits: int = 15

--- a/tests/handlers/test_asgi.py
+++ b/tests/handlers/test_asgi.py
@@ -3,13 +3,16 @@ from inline_snapshot import snapshot
 from litestar import (
     Litestar,
     Response,
+    WebSocket,
     get,
     post,
+    websocket,
 )
 from litestar.datastructures import (
     State,
 )
 from litestar.response import Stream
+from pywhatwgurl import URL
 
 from zapros import AsyncClient
 from zapros._compat import anysleep
@@ -19,7 +22,10 @@ from zapros._errors import (
 )
 from zapros._handlers._asgi import (
     AsgiHandler,
+    AsgiWebSocketStream,
 )
+from zapros._models import Request, Response as ZaprosResponse
+from zapros.websocket._errors import ConnectionClosed
 
 
 @get("/")
@@ -313,19 +319,20 @@ async def test_status_codes(
             assert response_500.status == snapshot(500)
 
 
-# async def test_lifespan_disabled(
-#     litestar_app_with_lifespan,
-# ):
-#     handler = AsgiHandler(
-#         litestar_app_with_lifespan,
-#         enable_lifespan=False,
-#     )
-#     async with AsyncClient(handler=handler) as client:
-#         response = await client.get(
-#             "http://testserver/state",
-#         )
-#         data = response.json
-#         assert data == snapshot({"startup_value": "not set"})
+async def test_lifespan_disabled(
+    litestar_app_with_lifespan,
+):
+    handler = AsgiHandler(
+        litestar_app_with_lifespan,
+        enable_lifespan=False,
+    )
+    async with handler:
+        async with AsyncClient(handler=handler) as client:
+            response = await client.get(
+                "http://testserver/state",
+            )
+            data = response.json
+            assert data == snapshot({"startup_value": "not set"})
 
 
 async def test_lifespan_enabled(
@@ -402,3 +409,139 @@ async def test_http_version():
         async with AsyncClient(handler=handler) as client:
             response = await client.get("http://testserver/")
             assert response.status == snapshot(200)
+
+
+def _ws_request(path: str = "/") -> Request:
+    return Request(URL(f"ws://testserver{path}"), method="GET")
+
+
+def _handoff(response: ZaprosResponse) -> AsgiWebSocketStream:
+    ws = response.context.get("handoff", {}).get("_asgi_websocket_stream")
+    assert isinstance(ws, AsgiWebSocketStream)
+    return ws
+
+
+class TestAsgiWebSocketStream:
+    async def test_handshake_accepted(self):
+        async def app(scope, receive, send):
+            assert scope["type"] == "websocket"
+            event = await receive()
+            assert event["type"] == "websocket.connect"
+            await send({"type": "websocket.accept"})
+            await receive()
+
+        async with AsgiHandler(app, enable_lifespan=False) as handler:
+            response = await handler.ahandle(_ws_request())
+            assert response.status == snapshot(101)
+            ws = _handoff(response)
+            assert ws.state == "connected"
+            await ws.aclose()
+
+    async def test_handshake_with_subprotocol_and_headers(self):
+        async def app(scope, receive, send):
+            await receive()
+            await send(
+                {
+                    "type": "websocket.accept",
+                    "subprotocol": "graphql-ws",
+                    "headers": [(b"x-extra", b"yes")],
+                }
+            )
+            await receive()
+
+        async with AsgiHandler(app, enable_lifespan=False) as handler:
+            response = await handler.ahandle(_ws_request())
+            ws = _handoff(response)
+            assert ws.accept_subprotocol == snapshot("graphql-ws")
+            assert ws.accept_headers == snapshot([("x-extra", "yes")])
+            await ws.aclose()
+
+    async def test_handshake_rejected_via_close(self):
+        async def app(scope, receive, send):
+            await receive()
+            await send({"type": "websocket.close", "code": 4000, "reason": "no thanks"})
+
+        async with AsgiHandler(app, enable_lifespan=False) as handler:
+            response = await handler.ahandle(_ws_request())
+            assert response.status == snapshot(403)
+            assert "_asgi_websocket_stream" not in response.context.get("handoff", {})
+
+    async def test_handshake_rejected_when_app_raises(self):
+        async def app(scope, receive, send):
+            raise RuntimeError("boom")
+
+        async with AsgiHandler(app, enable_lifespan=False) as handler:
+            response = await handler.ahandle(_ws_request())
+            assert response.status == snapshot(403)
+            assert "_asgi_websocket_stream" not in response.context.get("handoff", {})
+
+    async def test_send_and_receive_text(self):
+        async def app(scope, receive, send):
+            await receive()
+            await send({"type": "websocket.accept"})
+            msg = await receive()
+            assert msg["type"] == "websocket.receive"
+            await send({"type": "websocket.send", "text": f"echo:{msg['text']}"})
+            await receive()
+
+        async with AsgiHandler(app, enable_lifespan=False) as handler:
+            response = await handler.ahandle(_ws_request())
+            ws = _handoff(response)
+            await ws.asend(text="hello")
+            received = await ws.areceive()
+            assert received["type"] == snapshot("websocket.send")
+            assert received["text"] == snapshot("echo:hello")
+            await ws.aclose()
+
+    async def test_areceive_raises_on_app_close(self):
+        async def app(scope, receive, send):
+            await receive()
+            await send({"type": "websocket.accept"})
+            await send({"type": "websocket.close", "code": 4001, "reason": "done"})
+
+        async with AsgiHandler(app, enable_lifespan=False) as handler:
+            response = await handler.ahandle(_ws_request())
+            ws = _handoff(response)
+            with pytest.raises(ConnectionClosed) as exc_info:
+                await ws.areceive()
+            assert exc_info.value.code == snapshot(4001)
+            assert exc_info.value.reason == snapshot("done")
+            assert ws.state == "disconnected"
+            await ws.aclose()
+
+    async def test_asend_validation(
+        self,
+    ):
+        async def app(scope, receive, send):
+            await receive()
+            await send({"type": "websocket.accept"})
+            await receive()
+
+        async with AsgiHandler(app, enable_lifespan=False) as handler:
+            response = await handler.ahandle(_ws_request())
+            ws = _handoff(response)
+            with pytest.raises(ValueError):
+                await ws.asend()
+            with pytest.raises(ValueError):
+                await ws.asend(text="x", bytes=b"y")
+            await ws.aclose()
+
+    async def test_litestar_websocket_echo(self):
+        @websocket("/ws/echo")
+        async def echo(socket: WebSocket) -> None:
+            await socket.accept()
+            data = await socket.receive_text()
+            await socket.send_text(f"echo:{data}")
+            await socket.close()
+
+        app = Litestar(route_handlers=[echo])
+        async with AsgiHandler(app, enable_lifespan=False) as handler:
+            response = await handler.ahandle(_ws_request("/ws/echo"))
+            assert response.status == snapshot(101)
+            ws = _handoff(response)
+            await ws.asend(text="hello")
+            received = await ws.areceive()
+            assert received["text"] == snapshot("echo:hello")
+            with pytest.raises(ConnectionClosed):
+                await ws.areceive()
+            await ws.aclose()

--- a/tests/websocket/conftest.py
+++ b/tests/websocket/conftest.py
@@ -1,0 +1,13 @@
+import pytest
+
+from tests.websocket.ws_server import WebSocketTestServer
+
+
+@pytest.fixture(scope="session")
+def ws_server():
+    server = WebSocketTestServer()
+    server.start()
+    try:
+        yield server
+    finally:
+        server.stop()

--- a/tests/websocket/test_async.py
+++ b/tests/websocket/test_async.py
@@ -1,0 +1,81 @@
+import pytest
+from inline_snapshot import snapshot
+
+from tests.websocket.ws_server import WebSocketTestServer
+from zapros.websocket import BinaryMessage, CloseMessage, ConnectionClosed, TextMessage, aconnect_ws
+
+
+async def test_text_echo(ws_server: WebSocketTestServer):
+    async with aconnect_ws(f"{ws_server.url}/ws/echo-text") as ws:
+        await ws.send(TextMessage(data="hello"))
+        msg = await ws.recv()
+        assert msg == snapshot(TextMessage(data="echo:hello"))
+
+
+async def test_binary_echo(ws_server: WebSocketTestServer):
+    async with aconnect_ws(f"{ws_server.url}/ws/echo-binary") as ws:
+        await ws.send(BinaryMessage(data=b"\x00\x01\x02"))
+        msg = await ws.recv()
+        assert msg == snapshot(BinaryMessage(data=b"echo:\x00\x01\x02"))
+
+
+async def test_multiple_messages(ws_server: WebSocketTestServer):
+    async with aconnect_ws(f"{ws_server.url}/ws/echo-text") as ws:
+        for i in range(5):
+            await ws.send(TextMessage(data=f"msg-{i}"))
+        for i in range(5):
+            msg = await ws.recv()
+            assert msg == TextMessage(data=f"echo:msg-{i}")
+
+
+async def test_async_iteration(ws_server: WebSocketTestServer):
+    received: list[str] = []
+    async with aconnect_ws(f"{ws_server.url}/ws/send-then-close") as ws:
+        async for msg in ws:
+            assert isinstance(msg, TextMessage)
+            received.append(msg.data)
+
+    assert received == snapshot(["first", "second", "third"])
+
+
+async def test_server_initiated_close(ws_server: WebSocketTestServer):
+    async with aconnect_ws(f"{ws_server.url}/ws/close-immediately") as ws:
+        msg = await ws.recv()
+        assert msg == snapshot(CloseMessage(code=4001, reason="go away"))
+
+        with pytest.raises(ConnectionClosed):
+            await ws.recv()
+        assert ws.close_code == snapshot(4001)
+        assert ws.close_reason == snapshot("go away")
+
+
+async def test_client_initiated_close(ws_server: WebSocketTestServer):
+    async with aconnect_ws(f"{ws_server.url}/ws/echo-text") as ws:
+        await ws.send(TextMessage(data="ping"))
+        await ws.recv()
+        await ws.close(code=1000, reason="done")
+        assert ws.close_code == snapshot(1000)
+        assert ws.close_reason == snapshot("done")
+
+
+async def test_double_close_is_safe(ws_server: WebSocketTestServer):
+    async with aconnect_ws(f"{ws_server.url}/ws/echo-text") as ws:
+        await ws.close()
+        await ws.close()
+
+
+async def test_text_and_binary_on_same_connection(ws_server: WebSocketTestServer):
+    async with aconnect_ws(f"{ws_server.url}/ws/echo-any") as ws:
+        await ws.send(TextMessage(data="hi"))
+        msg = await ws.recv()
+        assert msg == snapshot(TextMessage(data="hi"))
+
+        await ws.send(BinaryMessage(data=b"bytes"))
+        msg = await ws.recv()
+        assert msg == snapshot(BinaryMessage(data=b"bytes"))
+
+
+async def test_handshake_fails_for_non_ws_path(ws_server: WebSocketTestServer):
+    with pytest.raises(RuntimeError, match="WebSocket handshake failed"):
+        async with aconnect_ws(f"{ws_server.url}/does-not-exist"):
+            pass

--- a/tests/websocket/test_sync.py
+++ b/tests/websocket/test_sync.py
@@ -1,0 +1,81 @@
+import pytest
+from inline_snapshot import snapshot
+
+from tests.websocket.ws_server import WebSocketTestServer
+from zapros.websocket import BinaryMessage, CloseMessage, ConnectionClosed, TextMessage, connect_ws
+
+
+def test_text_echo(ws_server: WebSocketTestServer):
+    with connect_ws(f"{ws_server.url}/ws/echo-text") as ws:
+        ws.send(TextMessage(data="hello"))
+        msg = ws.recv()
+        assert msg == snapshot(TextMessage(data="echo:hello"))
+
+
+def test_binary_echo(ws_server: WebSocketTestServer):
+    with connect_ws(f"{ws_server.url}/ws/echo-binary") as ws:
+        ws.send(BinaryMessage(data=b"\x00\x01\x02"))
+        msg = ws.recv()
+        assert msg == snapshot(BinaryMessage(data=b"echo:\x00\x01\x02"))
+
+
+def test_multiple_messages(ws_server: WebSocketTestServer):
+    with connect_ws(f"{ws_server.url}/ws/echo-text") as ws:
+        for i in range(5):
+            ws.send(TextMessage(data=f"msg-{i}"))
+        for i in range(5):
+            msg = ws.recv()
+            assert msg == TextMessage(data=f"echo:msg-{i}")
+
+
+def test_async_iteration(ws_server: WebSocketTestServer):
+    received: list[str] = []
+    with connect_ws(f"{ws_server.url}/ws/send-then-close") as ws:
+        for msg in ws:
+            assert isinstance(msg, TextMessage)
+            received.append(msg.data)
+
+    assert received == snapshot(["first", "second", "third"])
+
+
+def test_server_initiated_close(ws_server: WebSocketTestServer):
+    with connect_ws(f"{ws_server.url}/ws/close-immediately") as ws:
+        msg = ws.recv()
+        assert msg == snapshot(CloseMessage(code=4001, reason="go away"))
+
+        with pytest.raises(ConnectionClosed):
+            ws.recv()
+        assert ws.close_code == snapshot(4001)
+        assert ws.close_reason == snapshot("go away")
+
+
+def test_client_initiated_close(ws_server: WebSocketTestServer):
+    with connect_ws(f"{ws_server.url}/ws/echo-text") as ws:
+        ws.send(TextMessage(data="ping"))
+        ws.recv()
+        ws.close(code=1000, reason="done")
+        assert ws.close_code == snapshot(1000)
+        assert ws.close_reason == snapshot("done")
+
+
+def test_double_close_is_safe(ws_server: WebSocketTestServer):
+    with connect_ws(f"{ws_server.url}/ws/echo-text") as ws:
+        ws.close()
+        ws.close()
+
+
+def test_text_and_binary_on_same_connection(ws_server: WebSocketTestServer):
+    with connect_ws(f"{ws_server.url}/ws/echo-any") as ws:
+        ws.send(TextMessage(data="hi"))
+        msg = ws.recv()
+        assert msg == snapshot(TextMessage(data="hi"))
+
+        ws.send(BinaryMessage(data=b"bytes"))
+        msg = ws.recv()
+        assert msg == snapshot(BinaryMessage(data=b"bytes"))
+
+
+def test_handshake_fails_for_non_ws_path(ws_server: WebSocketTestServer):
+    with pytest.raises(RuntimeError, match="WebSocket handshake failed"):
+        with connect_ws(f"{ws_server.url}/does-not-exist"):
+            pass

--- a/tests/websocket/ws_server.py
+++ b/tests/websocket/ws_server.py
@@ -1,0 +1,136 @@
+import socket
+import subprocess
+import sys
+import time
+
+from litestar import Litestar, WebSocket, websocket
+
+
+@websocket("/ws/echo-text")
+async def ws_echo_text(socket: WebSocket) -> None:
+    await socket.accept()
+    while True:
+        try:
+            data = await socket.receive_text()
+        except Exception:
+            return
+        await socket.send_text(f"echo:{data}")
+
+
+@websocket("/ws/echo-binary")
+async def ws_echo_binary(socket: WebSocket) -> None:
+    await socket.accept()
+    while True:
+        try:
+            data = await socket.receive_bytes()
+        except Exception:
+            return
+        await socket.send_bytes(b"echo:" + data)
+
+
+@websocket("/ws/echo-any")
+async def ws_echo_any(socket: WebSocket) -> None:
+    await socket.accept()
+    while True:
+        try:
+            event = await socket.receive()
+        except Exception:
+            return
+        if event["type"] == "websocket.disconnect":
+            return
+        if "text" in event and event["text"] is not None:
+            await socket.send_text(event["text"])
+        elif "bytes" in event and event["bytes"] is not None:
+            await socket.send_bytes(event["bytes"])
+
+
+@websocket("/ws/send-then-close")
+async def ws_send_then_close(socket: WebSocket) -> None:
+    await socket.accept()
+    await socket.send_text("first")
+    await socket.send_text("second")
+    await socket.send_text("third")
+    await socket.close(code=1000, reason="bye")
+
+
+@websocket("/ws/close-immediately")
+async def ws_close_immediately(socket: WebSocket) -> None:
+    await socket.accept()
+    await socket.close(code=4001, reason="go away")
+
+
+app = Litestar(
+    route_handlers=[
+        ws_echo_text,
+        ws_echo_binary,
+        ws_echo_any,
+        ws_send_then_close,
+        ws_close_immediately,
+    ],
+)
+
+
+class WebSocketTestServer:
+    def __init__(self) -> None:
+        self.host = "127.0.0.1"
+        self.port = 0
+        self.process: subprocess.Popen[bytes] | None = None
+
+    @property
+    def url(self) -> str:
+        return f"http://{self.host}:{self.port}"
+
+    def start(self) -> None:
+        if self.process is not None:
+            return
+
+        self.port = _find_free_port(self.host)
+        self.process = subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "uvicorn",
+                "tests.websocket.ws_server:app",
+                "--host",
+                self.host,
+                "--port",
+                str(self.port),
+                "--log-level",
+                "warning",
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        _wait_until_up(self.host, self.port, self.process)
+
+    def stop(self) -> None:
+        if self.process is None:
+            return
+        self.process.terminate()
+        try:
+            self.process.wait(timeout=5.0)
+        except subprocess.TimeoutExpired:
+            try:
+                self.process.kill()
+            except Exception:
+                pass
+        self.process = None
+
+
+def _find_free_port(host: str) -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind((host, 0))
+        return int(sock.getsockname()[1])
+
+
+def _wait_until_up(host: str, port: int, process: subprocess.Popen[bytes]) -> None:
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise RuntimeError("websocket test server failed to start")
+        try:
+            with socket.create_connection((host, port), timeout=0.1):
+                return
+        except OSError:
+            time.sleep(0.05)
+    raise RuntimeError("websocket test server did not start in time")

--- a/uv.lock
+++ b/uv.lock
@@ -1766,6 +1766,9 @@ pyreqwest = [
 socks = [
     { name = "socksio" },
 ]
+websocket = [
+    { name = "wsproto" },
+]
 zstd = [
     { name = "zstandard" },
 ]
@@ -1787,6 +1790,7 @@ dev = [
     { name = "sniffio" },
     { name = "trio" },
     { name = "uvicorn" },
+    { name = "wsproto" },
 ]
 
 [package.metadata]
@@ -1798,9 +1802,10 @@ requires-dist = [
     { name = "pywhatwgurl", specifier = ">=0.1.0" },
     { name = "socksio", marker = "extra == 'socks'", specifier = ">=1.0.0" },
     { name = "typing-extensions", specifier = ">=4.15.0" },
+    { name = "wsproto", marker = "extra == 'websocket'", specifier = ">=1.2.0" },
     { name = "zstandard", marker = "extra == 'zstd'", specifier = ">=0.18.0" },
 ]
-provides-extras = ["brotli", "zstd", "pyreqwest", "caching", "socks"]
+provides-extras = ["brotli", "zstd", "pyreqwest", "caching", "socks", "websocket"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1818,6 +1823,7 @@ dev = [
     { name = "sniffio", specifier = ">=1.3.1" },
     { name = "trio", specifier = ">=0.33.0" },
     { name = "uvicorn", specifier = ">=0.38.0" },
+    { name = "wsproto", specifier = ">=1.3.2" },
 ]
 
 [[package]]


### PR DESCRIPTION
closes #9 

This PR adds WebSocket support to Zapros.

Previously, when Zapros encountered a 101 Upgrade response, it exposed the underlying connection stream as a handoff connection. This allowed users to take over the connection and use it however they wanted, for example:

```python
response = client.get(...)

if response.status == 101:
    handoff = response.context.get("handoff") # BaseNetworkStream
    print(handoff["network_stream"]) # bytes
    print(handoff["trailing_data"])
```

This PR builds on that feature by adding a small, HTTP-client-independent WebSocket implementation. It can also run on top of Zapros’s ASGIHandler for testing.

## Basic usage

Open a connection with `aconnect_ws` (async) or `connect_ws` (sync). Both are context managers that yield a WebSocket object and close the connection on exit.

::: code-group

```python [Async]
from zapros.websocket import (
    BinaryMessage,
    TextMessage,
    aconnect_ws,
)

async with aconnect_ws("wss://echo.example.com/ws") as ws:
    await ws.send(TextMessage(data="hello"))

    match await ws.recv():
        case TextMessage(data=text):
            print(f"text: {text}")
        case BinaryMessage(data=raw):
            print(f"binary: {len(raw)} bytes")
```

```python [Sync]
from zapros.websocket import (
    BinaryMessage,
    TextMessage,
    connect_ws,
)

with connect_ws("wss://echo.example.com/ws") as ws:
    ws.send(TextMessage(data="hello"))

    match ws.recv():
        case TextMessage(data=text):
            print(f"text: {text}")
        case BinaryMessage(data=raw):
            print(f"binary: {len(raw)} bytes")
```

:::

## Message types

All messages are tagged dataclasses. Use `match` or `isinstance` to discriminate:

| Type            | Payload  | Direction  |
| --------------- | -------- | ---------- |
| `TextMessage`   | `str`    | both       |
| `BinaryMessage` | `bytes`  | both       |
| `PingMessage`   | `bytes`  | both       |
| `PongMessage`   | `bytes`  | both       |
| `CloseMessage`  | code + reason | both  |

Pongs to incoming pings are sent automatically — you only need to handle `PingMessage` if you care about observing them.

## Iterating messages

WebSocket objects are iterable. Iteration yields application messages and stops cleanly when the peer sends a close frame.

::: code-group

```python [Async]
from zapros.websocket import (
    BinaryMessage,
    TextMessage,
    aconnect_ws,
)

async with aconnect_ws("wss://stream.example.com/ws") as ws:
    async for message in ws:
        match message:
            case TextMessage(data=text):
                print(text)
            case BinaryMessage(data=raw):
                print(len(raw))
```

```python [Sync]
from zapros.websocket import (
    BinaryMessage,
    TextMessage,
    connect_ws,
)

with connect_ws("wss://stream.example.com/ws") as ws:
    for message in ws:
        match message:
            case TextMessage(data=text):
                print(text)
            case BinaryMessage(data=raw):
                print(len(raw))
```

:::

## Sending binary data

Wrap `bytes` payloads in `BinaryMessage`:

```python
from zapros.websocket import BinaryMessage, aconnect_ws

async with aconnect_ws("wss://api.example.com/upload") as ws:
    await ws.send(BinaryMessage(data=b"\x00\x01\x02"))
```

## Subprotocols

Pass a list of preferred subprotocols. The server picks one and includes it in the handshake response:

```python
from zapros.websocket import aconnect_ws

async with aconnect_ws(
    "wss://api.example.com/ws",
    subprotocols=["graphql-ws", "json"],
) as ws:
    ...
```

## permessage-deflate

Enable the [permessage-deflate](https://datatracker.ietf.org/doc/html/rfc7692) extension by passing `permessage_deflate=True`, or pass a `PerMessageDeflateExtension` to customize the parameters:

```python
from zapros.websocket import (
    PerMessageDeflateExtension,
    aconnect_ws,
)

async with aconnect_ws(
    "wss://api.example.com/ws",
    permessage_deflate=PerMessageDeflateExtension(
        client_no_context_takeover=True,
        server_no_context_takeover=True,
        client_max_window_bits=12,
        server_max_window_bits=12,
    ),
) as ws:
    ...
```

## Reusing a client

Pass an existing `AsyncClient` / `Client` to share handlers, headers, cookies, and authentication with the rest of your code:

::: code-group

```python [Async]
from zapros import AsyncClient
from zapros.websocket import aconnect_ws

client = AsyncClient(
    headers={"Authorization": "Bearer token"},
)

async with aconnect_ws(
    "wss://api.example.com/ws",
    client=client,
) as ws:
    ...
```

```python [Sync]
from zapros import Client
from zapros.websocket import connect_ws

client = Client(
    headers={"Authorization": "Bearer token"},
)

with connect_ws(
    "wss://api.example.com/ws",
    client=client,
) as ws:
    ...
```

:::

The handshake is a normal `GET` request, so any handler middleware on the client (auth, cookies, custom headers) participates in it.

## Testing ASGI applications

Because the WebSocket handshake goes through the client's handler stack, an `AsyncClient` configured with [`AsgiHandler`](/asgi) lets you drive your ASGI app's WebSocket endpoints directly — no real network, no separate test server.

```python
from litestar import Litestar
from litestar.handlers import websocket_listener

from zapros import AsgiHandler, AsyncClient
from zapros.websocket import TextMessage, aconnect_ws


@websocket_listener("/echo")
async def echo(data: str) -> str:
    return data


app = Litestar(route_handlers=[echo])

async with AsyncClient(handler=AsgiHandler(app)) as client:
    async with aconnect_ws(
        "ws://testserver/echo",
        client=client,
    ) as ws:
        await ws.send(TextMessage(data="hello"))

        match await ws.recv():
            case TextMessage(data=text):
                assert text == "hello"
```

The same `aconnect_ws` API works against the in-process ASGI app exactly as it does against a real server, so test code and production code stay symmetric.

::: tip ASGI WebSocket framing
The ASGI WebSocket spec only carries text and binary payloads — there is no in-band representation of `Ping` / `Pong` frames. Sending `PingMessage` or `PongMessage` over an ASGI-backed connection is a silent no-op, so heartbeat code written against a real network connection still works under test.
:::

## Closing

Leaving the `with` / `async with` block closes the connection with code `1000` (normal closure). To send a specific close code or reason, call `close()` explicitly before exiting:

```python
from zapros.websocket import CloseCode, aconnect_ws

async with aconnect_ws("wss://api.example.com/ws") as ws:
    await ws.close(
        code=CloseCode.GOING_AWAY,
        reason="client shutting down",
    )
```

After the connection closes, `ws.close_code` and `ws.close_reason` expose the negotiated close code and reason.

## Error handling

Calling `send` or `recv` on a closed connection raises `ConnectionClosed`. The exception carries the close code and reason, so you can distinguish a clean close from an abnormal one:

```python
from zapros.websocket import (
    CloseCode,
    ConnectionClosed,
    TextMessage,
    aconnect_ws,
)

async with aconnect_ws("wss://api.example.com/ws") as ws:
    try:
        while True:
            await ws.send(TextMessage(data="ping"))
            await ws.recv()
    except ConnectionClosed as exc:
        if exc.code == CloseCode.NORMAL:
            print("server closed cleanly")
        else:
            print(f"closed with {exc.code}: {exc.reason}")
```

When iterating with `async for` / `for`, a peer-initiated close ends the loop without raising — the loop simply stops at the close frame.
