### PR TITLE
fix(perf): reduce byte copies in the response-body pipeline

### DIFF
--- a/src/zapros/_decoders.py
+++ b/src/zapros/_decoders.py
@@ -46,8 +46,8 @@ class IdentityDecoder:
         self._chunk_size = chunk_size
 
     def decode(self, data: bytes) -> Iterator[bytes]:
-        for i in range(0, len(data), self._chunk_size):
-            yield data[i : i + self._chunk_size]
+        if data:
+            yield data
 
     def flush(self) -> Iterator[bytes]:
         yield from ()
@@ -231,11 +231,25 @@ class ByteChunker:
         self._buffer = bytearray()
 
     def feed(self, data: bytes) -> Iterator[bytes]:
-        self._buffer.extend(data)
-        while len(self._buffer) >= self._chunk_size:
-            chunk = bytes(self._buffer[: self._chunk_size])
-            del self._buffer[: self._chunk_size]
-            yield chunk
+        if not data:
+            return
+        size, data_length, view, position = self._chunk_size, len(data), memoryview(data), 0
+        try:
+            if self._buffer:
+                take = min(size - len(self._buffer), data_length)
+                self._buffer += view[:take]
+                position = take
+                if len(self._buffer) < size:
+                    return
+                yield bytes(self._buffer)
+                self._buffer.clear()
+            while data_length - position >= size:
+                yield bytes(view[position : position + size])
+                position += size
+            if position < data_length:
+                self._buffer += view[position:]
+        finally:
+            view.release()
 
     def flush(self) -> bytes:
         if self._buffer:

--- a/tests/test_decoders.py
+++ b/tests/test_decoders.py
@@ -15,9 +15,9 @@ from zapros._decoders import (
 )
 
 
-def test_identity_decoder():
+def test_identity_decoder_content_pass_untuched():
     decoder = IdentityDecoder(chunk_size=4)
-    assert list(decoder.decode(b"Hello, World!")) == [b"Hell", b"o, W", b"orld", b"!"]
+    assert list(decoder.decode(b"Hello, World!")) == [b"Hello, World!"]
     assert list(decoder.flush()) == []
 
 


### PR DESCRIPTION
Closes #43 

- Fixed perf issue about  byte copies in the response-body pipeline
- Added pipeline with pytest-codspeed accoring to this [instruction](https://codspeed.io/docs/integrations/ci/github-actions) and couple of tests