### PR TITLE
feat: add support for request trailing headers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,8 @@ exclude = [
     "tests/handlers/test_sync_caching.py",
     "src/zapros/websocket/_sync.py",
     "tests/websocket/test_sync.py",
+    "tests/handlers/test_sync_http1.py",
+    "tests/handlers/test_sync_http2.py",
 ]
 
 [tool.ruff.lint]

--- a/ry.yml
+++ b/ry.yml
@@ -264,6 +264,22 @@ targets:
   - input: tests/handlers/test_async_proxy.py
     output: tests/handlers/test_sync_proxy.py
 
+  - input: tests/handlers/test_async_http1.py
+    output: tests/handlers/test_sync_http1.py
+    rules:
+      - match: '\bAsyncMockStream\b'
+        replace: 'MockStream'
+      - match: '\bAsyncIterator\b'
+        replace: 'Iterator'
+
+  - input: tests/handlers/test_async_http2.py
+    output: tests/handlers/test_sync_http2.py
+    rules:
+      - match: '\bAsyncMockStream\b'
+        replace: 'MockStream'
+      - match: '\bAsyncRecordingStream\b'
+        replace: 'RecordingStream'
+
   - input: tests/test_async_pool.py
     output: tests/test_sync_pool.py
     rules:

--- a/src/zapros/_async_client.py
+++ b/src/zapros/_async_client.py
@@ -176,6 +176,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         json: Any,
     ) -> Response: ...
 
@@ -196,6 +197,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         form: Union[
             str,
             Iterable[Sequence[str]],
@@ -221,6 +223,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         body: bytes | AsyncStream,
     ) -> Response: ...
 
@@ -241,6 +244,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         multipart: "Multipart",
     ) -> Response: ...
 
@@ -261,6 +265,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
     ) -> Response: ...
 
     async def request(
@@ -279,6 +284,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         json: Any | None = None,
         form: Union[
             str,
@@ -305,6 +311,7 @@ class AsyncClient:
                 url=url_obj,
                 headers=merged_headers,
                 context=context,
+                trailers=trailers,
                 json=json,
             )
         elif form is not None:
@@ -313,6 +320,7 @@ class AsyncClient:
                 url=url_obj,
                 headers=merged_headers,
                 context=context,
+                trailers=trailers,
                 form=form,
             )
         elif multipart is not None:
@@ -321,6 +329,7 @@ class AsyncClient:
                 url=url_obj,
                 headers=merged_headers,
                 context=context,
+                trailers=trailers,
                 multipart=multipart,
             )
         elif body is not None:
@@ -329,6 +338,7 @@ class AsyncClient:
                 url=url_obj,
                 headers=merged_headers,
                 context=context,
+                trailers=trailers,
                 body=body,
             )
         else:
@@ -337,6 +347,7 @@ class AsyncClient:
                 url=url_obj,
                 headers=merged_headers,
                 context=context,
+                trailers=trailers,
             )
 
         try:
@@ -367,6 +378,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
     ) -> Response:
         return await self.request(
             "GET",
@@ -376,6 +388,7 @@ class AsyncClient:
             auth=auth,
             context=context,
             handler=handler,
+            trailers=trailers,
         )
 
     @overload
@@ -394,6 +407,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         json: Any,
     ) -> Response: ...
 
@@ -413,6 +427,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         form: Union[
             str,
             Iterable[Sequence[str]],
@@ -437,6 +452,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         body: bytes | AsyncStream,
     ) -> Response: ...
 
@@ -456,6 +472,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         multipart: "Multipart",
     ) -> Response: ...
 
@@ -475,6 +492,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
     ) -> Response: ...
 
     async def post(
@@ -492,6 +510,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         json: Any | None = None,
         form: Union[
             str,
@@ -511,6 +530,7 @@ class AsyncClient:
             auth=auth,
             context=context,
             handler=handler,
+            trailers=trailers,
             json=json,
             form=form,
             body=body,
@@ -533,6 +553,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         json: Any,
     ) -> Response: ...
 
@@ -552,6 +573,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         form: Union[
             str,
             Iterable[Sequence[str]],
@@ -576,6 +598,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         body: bytes | AsyncStream,
     ) -> Response: ...
 
@@ -595,6 +618,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         multipart: "Multipart",
     ) -> Response: ...
 
@@ -614,6 +638,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
     ) -> Response: ...
 
     async def put(
@@ -631,6 +656,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         json: Any | None = None,
         form: Union[
             str,
@@ -650,6 +676,7 @@ class AsyncClient:
             auth=auth,
             context=context,
             handler=handler,
+            trailers=trailers,
             json=json,
             form=form,
             body=body,
@@ -672,6 +699,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         json: Any,
     ) -> Response: ...
 
@@ -691,6 +719,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         form: Union[
             str,
             Iterable[Sequence[str]],
@@ -715,6 +744,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         body: bytes | AsyncStream,
     ) -> Response: ...
 
@@ -734,6 +764,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         multipart: "Multipart",
     ) -> Response: ...
 
@@ -753,6 +784,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
     ) -> Response: ...
 
     async def patch(
@@ -770,6 +802,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         json: Any | None = None,
         form: Union[
             str,
@@ -789,6 +822,7 @@ class AsyncClient:
             auth=auth,
             context=context,
             handler=handler,
+            trailers=trailers,
             json=json,
             form=form,
             body=body,
@@ -811,6 +845,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         json: Any,
     ) -> Response: ...
 
@@ -830,6 +865,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         form: Union[
             str,
             Iterable[Sequence[str]],
@@ -854,6 +890,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         body: bytes | AsyncStream,
     ) -> Response: ...
 
@@ -873,6 +910,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         multipart: "Multipart",
     ) -> Response: ...
 
@@ -892,6 +930,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
     ) -> Response: ...
 
     async def delete(
@@ -909,6 +948,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         json: Any | None = None,
         form: Union[
             str,
@@ -928,6 +968,7 @@ class AsyncClient:
             auth=auth,
             context=context,
             handler=handler,
+            trailers=trailers,
             json=json,
             form=form,
             body=body,
@@ -949,6 +990,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
     ) -> Response:
         return await self.request(
             "HEAD",
@@ -958,6 +1000,7 @@ class AsyncClient:
             auth=auth,
             context=context,
             handler=handler,
+            trailers=trailers,
         )
 
     @overload
@@ -976,6 +1019,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         json: Any,
     ) -> Response: ...
 
@@ -995,6 +1039,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         form: Union[
             str,
             Iterable[Sequence[str]],
@@ -1019,6 +1064,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         body: bytes | AsyncStream,
     ) -> Response: ...
 
@@ -1038,6 +1084,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         multipart: "Multipart",
     ) -> Response: ...
 
@@ -1057,6 +1104,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
     ) -> Response: ...
 
     async def query(
@@ -1074,6 +1122,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         json: Any | None = None,
         form: Union[
             str,
@@ -1093,6 +1142,7 @@ class AsyncClient:
             auth=auth,
             context=context,
             handler=handler,
+            trailers=trailers,
             json=json,
             form=form,
             body=body,
@@ -1115,6 +1165,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         json: Any,
     ) -> Response: ...
 
@@ -1134,6 +1185,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         form: Union[
             str,
             Iterable[Sequence[str]],
@@ -1158,6 +1210,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         body: bytes | AsyncStream,
     ) -> Response: ...
 
@@ -1177,6 +1230,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         multipart: "Multipart",
     ) -> Response: ...
 
@@ -1196,6 +1250,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
     ) -> Response: ...
 
     async def options(
@@ -1213,6 +1268,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         json: Any | None = None,
         form: Union[
             str,
@@ -1232,6 +1288,7 @@ class AsyncClient:
             auth=auth,
             context=context,
             handler=handler,
+            trailers=trailers,
             json=json,
             form=form,
             body=body,
@@ -1255,6 +1312,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         json: Any,
     ) -> AbstractAsyncContextManager[Response]: ...
 
@@ -1275,6 +1333,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         form: Union[
             str,
             Iterable[Sequence[str]],
@@ -1300,6 +1359,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         body: bytes | AsyncStream,
     ) -> AbstractAsyncContextManager[Response]: ...
 
@@ -1320,6 +1380,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         multipart: "Multipart",
     ) -> AbstractAsyncContextManager[Response]: ...
 
@@ -1340,6 +1401,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
     ) -> AbstractAsyncContextManager[Response]: ...
 
     @asynccontextmanager  # type: ignore
@@ -1359,6 +1421,7 @@ class AsyncClient:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: AsyncBaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         json: Any | None = None,
         form: Union[
             str,
@@ -1384,6 +1447,7 @@ class AsyncClient:
                 url=url_obj,
                 headers=merged_headers,
                 context=context,
+                trailers=trailers,
                 json=json,
             )
         elif form is not None:
@@ -1392,6 +1456,7 @@ class AsyncClient:
                 url=url_obj,
                 headers=merged_headers,
                 context=context,
+                trailers=trailers,
                 form=form,
             )
         elif multipart is not None:
@@ -1400,6 +1465,7 @@ class AsyncClient:
                 url=url_obj,
                 headers=merged_headers,
                 context=context,
+                trailers=trailers,
                 multipart=multipart,
             )
         elif body is not None:
@@ -1408,6 +1474,7 @@ class AsyncClient:
                 url=url_obj,
                 headers=merged_headers,
                 context=context,
+                trailers=trailers,
                 body=body,
             )
         else:
@@ -1416,6 +1483,7 @@ class AsyncClient:
                 url=url_obj,
                 headers=merged_headers,
                 context=context,
+                trailers=trailers,
             )
 
         response = await handler.ahandle(request=request)

--- a/src/zapros/_handlers/_cassette.py
+++ b/src/zapros/_handlers/_cassette.py
@@ -341,6 +341,7 @@ class CassetteMiddleware(AsyncBaseMiddleware, BaseMiddleware):
             method=request.method,
             url=request.url,
             headers=Headers(dict(request.headers)),
+            trailers=request.trailers,
             body=b"".join([chunk async for chunk in body]),  # type: ignore
         )
 
@@ -353,6 +354,7 @@ class CassetteMiddleware(AsyncBaseMiddleware, BaseMiddleware):
             method=request.method,
             url=request.url,
             headers=Headers(dict(request.headers)),
+            trailers=request.trailers,
             body=b"".join(body),  # type: ignore
         )
 

--- a/src/zapros/_handlers/_redirect.py
+++ b/src/zapros/_handlers/_redirect.py
@@ -133,6 +133,7 @@ class RedirectMiddleware(AsyncBaseMiddleware, BaseMiddleware):
                 new_method,
                 headers=new_headers_dict,
                 body=original_request.body,
+                trailers=original_request.trailers,
                 context=original_request.context.copy(),
             )
         else:

--- a/src/zapros/_handlers/_std/_async_http1.py
+++ b/src/zapros/_handlers/_std/_async_http1.py
@@ -18,7 +18,7 @@ from zapros._handlers._std._common import (
 )
 from zapros._handlers._std._conn import AsyncHttpConnection
 from zapros._io._base import AsyncBaseNetworkStream
-from zapros._models import AsyncClosableStream, Request, Response, ResponseHandoffContext
+from zapros._models import AsyncClosableStream, Headers, Request, Response, ResponseHandoffContext
 from zapros._utils import get_pool_key
 
 
@@ -194,6 +194,14 @@ class AsyncHttp1Connection(AsyncHttpConnection):
         target = str(request.url) if use_full_url else f"{request.url.pathname}{request.url.search}"
 
         request_headers_list = request.headers.list()
+        if request.trailers is not None:
+            # HTTP/1.1 can only carry trailers in a chunked body.
+            request_headers_list = [(k, v) for k, v in request_headers_list if k.lower() != "content-length"]
+            if not any(k.lower() == "transfer-encoding" for k, _ in request_headers_list):
+                request_headers_list.append(("Transfer-Encoding", "chunked"))
+            # Announce the trailer fields known at this point; a streaming body may add more later.
+            if request.trailers and "trailer" not in request.headers:
+                request_headers_list.append(("Trailer", ", ".join(request.trailers)))
 
         try:
             await self._send_request_headers(
@@ -210,6 +218,7 @@ class AsyncHttp1Connection(AsyncHttpConnection):
 
         await self._send_request_body(
             body=request.body,
+            trailers=request.trailers,
             write_timeout=write_timeout,
             deadline=deadline,
         )
@@ -286,6 +295,7 @@ class AsyncHttp1Connection(AsyncHttpConnection):
         self,
         body: bytes | AsyncIterator[bytes] | None,
         *,
+        trailers: Headers | None = None,
         write_timeout: float | None = None,
         deadline: float | None = None,
     ) -> None:
@@ -306,8 +316,21 @@ class AsyncHttp1Connection(AsyncHttpConnection):
             pass
         else:
             raise TypeError(f"Unsupported body type: {body.__class__.__name__}")
+        # Read trailers only now: a streaming body may have populated them.
+        if trailers:
+            end_of_message = h11.EndOfMessage(
+                headers=[
+                    (
+                        k.encode("ascii"),
+                        v.encode("latin-1"),
+                    )
+                    for k, v in trailers.list()
+                ],
+            )
+        else:
+            end_of_message = h11.EndOfMessage()
         await self.stream.write_all(
-            self.h11.send(h11.EndOfMessage()),
+            self.h11.send(end_of_message),
             timeout=min_with_optionals(write_timeout, remaining_timeout_or_raise(deadline)),
         )
 

--- a/src/zapros/_handlers/_std/_async_http2.py
+++ b/src/zapros/_handlers/_std/_async_http2.py
@@ -64,7 +64,7 @@ from zapros._errors import ConnectionError
 from zapros._handlers._common import min_with_optionals
 from zapros._handlers._std._common import AsyncStreamLimiter, BrokenConnectionError, remaining_timeout_or_raise
 from zapros._io._base import AsyncBaseNetworkStream
-from zapros._models import AsyncClosableStream, Request, Response
+from zapros._models import AsyncClosableStream, Headers, Request, Response
 from zapros._typing import is_sync_iterator
 from zapros._utils import get_host_header_value
 
@@ -153,6 +153,10 @@ def _build_h2_headers(request: Request) -> list[tuple[bytes, bytes]]:
             continue
         user.append((lk.encode("ascii"), v.encode("latin-1")))
 
+    # Announce the trailer fields known at this point; a streaming body may add more later.
+    if request.trailers and "trailer" not in request.headers:
+        user.append((b"trailer", ", ".join(request.trailers).encode("ascii")))
+
     return pseudo + user
 
 
@@ -234,7 +238,8 @@ class AsyncHttp2Connection(AsyncHttpConnection):
 
         stream_id = await self._allocate_stream_and_send_headers(
             request,
-            has_body=has_body,
+            # Trailers are sent in a final HEADERS frame, so the stream must stay open.
+            end_stream=not has_body and request.trailers is None,
             write_timeout=write_timeout,
             deadline=deadline,
         )
@@ -245,7 +250,15 @@ class AsyncHttp2Connection(AsyncHttpConnection):
                 await self._send_request_body(
                     request.body,
                     stream_id,
+                    trailers=request.trailers,
                     read_timeout=read_timeout,
+                    write_timeout=write_timeout,
+                    deadline=deadline,
+                )
+            elif request.trailers is not None:
+                await self._end_stream(
+                    stream_id,
+                    request.trailers,
                     write_timeout=write_timeout,
                     deadline=deadline,
                 )
@@ -326,7 +339,7 @@ class AsyncHttp2Connection(AsyncHttpConnection):
         self,
         request: Request,
         *,
-        has_body: bool,
+        end_stream: bool,
         write_timeout: float | None = None,
         deadline: float | None = None,
     ) -> int:
@@ -342,7 +355,7 @@ class AsyncHttp2Connection(AsyncHttpConnection):
                     self._connection_terminated = True
                     raise ConnectionError("HTTP/2 connection has no available stream ids") from e
                 self.events[stream_id] = []
-                self.h2.send_headers(stream_id, headers, end_stream=not has_body)
+                self.h2.send_headers(stream_id, headers, end_stream=end_stream)
                 data = self.h2.data_to_send()
             if data:
                 async with self._write_lock:
@@ -401,6 +414,7 @@ class AsyncHttp2Connection(AsyncHttpConnection):
         body: bytes | AsyncIterator[bytes],
         stream_id: int,
         *,
+        trailers: Headers | None = None,
         read_timeout: float | None = None,
         write_timeout: float | None = None,
         deadline: float | None = None,
@@ -432,8 +446,26 @@ class AsyncHttp2Connection(AsyncHttpConnection):
                             timeout=min_with_optionals(write_timeout, remaining_timeout_or_raise(deadline)),
                         )
 
+        await self._end_stream(stream_id, trailers, write_timeout=write_timeout, deadline=deadline)
+
+    async def _end_stream(
+        self,
+        stream_id: int,
+        trailers: Headers | None,
+        *,
+        write_timeout: float | None = None,
+        deadline: float | None = None,
+    ) -> None:
+        # Read trailers only now: a streaming body may have populated them.
         async with self.state_lock:
-            self.h2.end_stream(stream_id)
+            if trailers:
+                self.h2.send_headers(
+                    stream_id,
+                    [(k.lower().encode("ascii"), v.encode("latin-1")) for k, v in trailers.list()],
+                    end_stream=True,
+                )
+            else:
+                self.h2.end_stream(stream_id)
             data = self.h2.data_to_send()
         if data:
             async with self._write_lock:

--- a/src/zapros/_handlers/_std/_sync_http1.py
+++ b/src/zapros/_handlers/_std/_sync_http1.py
@@ -18,7 +18,7 @@ from zapros._handlers._std._common import (
 )
 from zapros._handlers._std._conn import HttpConnection
 from zapros._io._base import BaseNetworkStream
-from zapros._models import ClosableStream, Request, Response, ResponseHandoffContext
+from zapros._models import ClosableStream, Headers, Request, Response, ResponseHandoffContext
 from zapros._utils import get_pool_key
 
 
@@ -194,6 +194,14 @@ class Http1Connection(HttpConnection):
         target = str(request.url) if use_full_url else f"{request.url.pathname}{request.url.search}"
 
         request_headers_list = request.headers.list()
+        if request.trailers is not None:
+            # HTTP/1.1 can only carry trailers in a chunked body.
+            request_headers_list = [(k, v) for k, v in request_headers_list if k.lower() != "content-length"]
+            if not any(k.lower() == "transfer-encoding" for k, _ in request_headers_list):
+                request_headers_list.append(("Transfer-Encoding", "chunked"))
+            # Announce the trailer fields known at this point; a streaming body may add more later.
+            if request.trailers and "trailer" not in request.headers:
+                request_headers_list.append(("Trailer", ", ".join(request.trailers)))
 
         try:
             self._send_request_headers(
@@ -210,6 +218,7 @@ class Http1Connection(HttpConnection):
 
         self._send_request_body(
             body=request.body,
+            trailers=request.trailers,
             write_timeout=write_timeout,
             deadline=deadline,
         )
@@ -286,6 +295,7 @@ class Http1Connection(HttpConnection):
         self,
         body: bytes | Iterator[bytes] | None,
         *,
+        trailers: Headers | None = None,
         write_timeout: float | None = None,
         deadline: float | None = None,
     ) -> None:
@@ -306,8 +316,21 @@ class Http1Connection(HttpConnection):
             pass
         else:
             raise TypeError(f"Unsupported body type: {body.__class__.__name__}")
+        # Read trailers only now: a streaming body may have populated them.
+        if trailers:
+            end_of_message = h11.EndOfMessage(
+                headers=[
+                    (
+                        k.encode("ascii"),
+                        v.encode("latin-1"),
+                    )
+                    for k, v in trailers.list()
+                ],
+            )
+        else:
+            end_of_message = h11.EndOfMessage()
         self.stream.write_all(
-            self.h11.send(h11.EndOfMessage()),
+            self.h11.send(end_of_message),
             timeout=min_with_optionals(write_timeout, remaining_timeout_or_raise(deadline)),
         )
 

--- a/src/zapros/_handlers/_std/_sync_http2.py
+++ b/src/zapros/_handlers/_std/_sync_http2.py
@@ -64,7 +64,7 @@ from zapros._errors import ConnectionError
 from zapros._handlers._common import min_with_optionals
 from zapros._handlers._std._common import StreamLimiter, BrokenConnectionError, remaining_timeout_or_raise
 from zapros._io._base import BaseNetworkStream
-from zapros._models import ClosableStream, Request, Response
+from zapros._models import ClosableStream, Headers, Request, Response
 from zapros._typing import is_async_iterator
 from zapros._utils import get_host_header_value
 
@@ -153,6 +153,10 @@ def _build_h2_headers(request: Request) -> list[tuple[bytes, bytes]]:
             continue
         user.append((lk.encode("ascii"), v.encode("latin-1")))
 
+    # Announce the trailer fields known at this point; a streaming body may add more later.
+    if request.trailers and "trailer" not in request.headers:
+        user.append((b"trailer", ", ".join(request.trailers).encode("ascii")))
+
     return pseudo + user
 
 
@@ -234,7 +238,8 @@ class Http2Connection(HttpConnection):
 
         stream_id = self._allocate_stream_and_send_headers(
             request,
-            has_body=has_body,
+            # Trailers are sent in a final HEADERS frame, so the stream must stay open.
+            end_stream=not has_body and request.trailers is None,
             write_timeout=write_timeout,
             deadline=deadline,
         )
@@ -245,7 +250,15 @@ class Http2Connection(HttpConnection):
                 self._send_request_body(
                     request.body,
                     stream_id,
+                    trailers=request.trailers,
                     read_timeout=read_timeout,
+                    write_timeout=write_timeout,
+                    deadline=deadline,
+                )
+            elif request.trailers is not None:
+                self._end_stream(
+                    stream_id,
+                    request.trailers,
                     write_timeout=write_timeout,
                     deadline=deadline,
                 )
@@ -326,7 +339,7 @@ class Http2Connection(HttpConnection):
         self,
         request: Request,
         *,
-        has_body: bool,
+        end_stream: bool,
         write_timeout: float | None = None,
         deadline: float | None = None,
     ) -> int:
@@ -342,7 +355,7 @@ class Http2Connection(HttpConnection):
                     self._connection_terminated = True
                     raise ConnectionError("HTTP/2 connection has no available stream ids") from e
                 self.events[stream_id] = []
-                self.h2.send_headers(stream_id, headers, end_stream=not has_body)
+                self.h2.send_headers(stream_id, headers, end_stream=end_stream)
                 data = self.h2.data_to_send()
             if data:
                 with self._write_lock:
@@ -401,6 +414,7 @@ class Http2Connection(HttpConnection):
         body: bytes | Iterator[bytes],
         stream_id: int,
         *,
+        trailers: Headers | None = None,
         read_timeout: float | None = None,
         write_timeout: float | None = None,
         deadline: float | None = None,
@@ -432,8 +446,26 @@ class Http2Connection(HttpConnection):
                             timeout=min_with_optionals(write_timeout, remaining_timeout_or_raise(deadline)),
                         )
 
+        self._end_stream(stream_id, trailers, write_timeout=write_timeout, deadline=deadline)
+
+    def _end_stream(
+        self,
+        stream_id: int,
+        trailers: Headers | None,
+        *,
+        write_timeout: float | None = None,
+        deadline: float | None = None,
+    ) -> None:
+        # Read trailers only now: a streaming body may have populated them.
         with self.state_lock:
-            self.h2.end_stream(stream_id)
+            if trailers:
+                self.h2.send_headers(
+                    stream_id,
+                    [(k.lower().encode("ascii"), v.encode("latin-1")) for k, v in trailers.list()],
+                    end_stream=True,
+                )
+            else:
+                self.h2.end_stream(stream_id)
             data = self.h2.data_to_send()
         if data:
             with self._write_lock:

--- a/src/zapros/_models.py
+++ b/src/zapros/_models.py
@@ -192,6 +192,7 @@ class Request:
         "method",
         "headers",
         "body",
+        "trailers",
         "context",
     )
 
@@ -203,6 +204,7 @@ class Request:
         headers: Headers | Mapping[str, str] | None = None,
         *,
         json: Any | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         context: RequestContext | None = None,
     ) -> None: ...
 
@@ -220,6 +222,7 @@ class Request:
             URLSearchParams,
         ]
         | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         context: RequestContext | None = None,
     ) -> None: ...
 
@@ -231,6 +234,7 @@ class Request:
         headers: Headers | Mapping[str, str] | None = None,
         *,
         body: bytes | Stream | AsyncStream | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         context: RequestContext | None = None,
     ) -> None: ...
 
@@ -242,6 +246,7 @@ class Request:
         headers: Headers | Mapping[str, str] | None = None,
         *,
         multipart: "Multipart | None" = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         context: RequestContext | None = None,
     ) -> None: ...
 
@@ -253,6 +258,7 @@ class Request:
         headers: Headers | Mapping[str, str] | None = None,
         *,
         text: str | None,
+        trailers: Headers | Mapping[str, str] | None = None,
         context: RequestContext | None = None,
     ) -> None: ...
 
@@ -273,12 +279,19 @@ class Request:
         body: bytes | Stream | AsyncStream | None = None,
         multipart: "Multipart | None" = None,
         text: str | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         context: RequestContext | None = None,
     ) -> None:
         self.url = url
         self.method = method
         self.headers: Headers = headers if isinstance(headers, Headers) else Headers(headers)
         self.context: RequestContext = context if context is not None else {}
+        # Trailers are read by the transport only after the body has been fully
+        # sent, so a streaming body may populate them while it is being consumed.
+        # Framing (chunked vs. Content-Length) is the transport's concern.
+        self.trailers: Headers | None = (
+            None if trailers is None else trailers if isinstance(trailers, Headers) else Headers(trailers)
+        )
 
         if "host" not in self.headers and url.hostname:
             self.headers.add(

--- a/src/zapros/_sync_client.py
+++ b/src/zapros/_sync_client.py
@@ -175,6 +175,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         json: Any,
     ) -> Response: ...
 
@@ -195,6 +196,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         form: Union[
             str,
             Iterable[Sequence[str]],
@@ -220,6 +222,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         body: bytes | Stream,
     ) -> Response: ...
 
@@ -240,6 +243,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         multipart: "Multipart",
     ) -> Response: ...
 
@@ -260,6 +264,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
     ) -> Response: ...
 
     def request(
@@ -278,6 +283,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         json: Any | None = None,
         form: Union[
             str,
@@ -304,6 +310,7 @@ class Client:
                 url=url_obj,
                 headers=merged_headers,
                 context=context,
+                trailers=trailers,
                 json=json,
             )
         elif form is not None:
@@ -312,6 +319,7 @@ class Client:
                 url=url_obj,
                 headers=merged_headers,
                 context=context,
+                trailers=trailers,
                 form=form,
             )
         elif multipart is not None:
@@ -320,6 +328,7 @@ class Client:
                 url=url_obj,
                 headers=merged_headers,
                 context=context,
+                trailers=trailers,
                 multipart=multipart,
             )
         elif body is not None:
@@ -328,6 +337,7 @@ class Client:
                 url=url_obj,
                 headers=merged_headers,
                 context=context,
+                trailers=trailers,
                 body=body,
             )
         else:
@@ -336,6 +346,7 @@ class Client:
                 url=url_obj,
                 headers=merged_headers,
                 context=context,
+                trailers=trailers,
             )
 
         try:
@@ -366,6 +377,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
     ) -> Response:
         return self.request(
             "GET",
@@ -375,6 +387,7 @@ class Client:
             auth=auth,
             context=context,
             handler=handler,
+            trailers=trailers,
         )
 
     @overload
@@ -393,6 +406,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         json: Any,
     ) -> Response: ...
 
@@ -412,6 +426,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         form: Union[
             str,
             Iterable[Sequence[str]],
@@ -436,6 +451,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         body: bytes | Stream,
     ) -> Response: ...
 
@@ -455,6 +471,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         multipart: "Multipart",
     ) -> Response: ...
 
@@ -474,6 +491,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
     ) -> Response: ...
 
     def post(
@@ -491,6 +509,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         json: Any | None = None,
         form: Union[
             str,
@@ -510,6 +529,7 @@ class Client:
             auth=auth,
             context=context,
             handler=handler,
+            trailers=trailers,
             json=json,
             form=form,
             body=body,
@@ -532,6 +552,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         json: Any,
     ) -> Response: ...
 
@@ -551,6 +572,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         form: Union[
             str,
             Iterable[Sequence[str]],
@@ -575,6 +597,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         body: bytes | Stream,
     ) -> Response: ...
 
@@ -594,6 +617,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         multipart: "Multipart",
     ) -> Response: ...
 
@@ -613,6 +637,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
     ) -> Response: ...
 
     def put(
@@ -630,6 +655,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         json: Any | None = None,
         form: Union[
             str,
@@ -649,6 +675,7 @@ class Client:
             auth=auth,
             context=context,
             handler=handler,
+            trailers=trailers,
             json=json,
             form=form,
             body=body,
@@ -671,6 +698,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         json: Any,
     ) -> Response: ...
 
@@ -690,6 +718,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         form: Union[
             str,
             Iterable[Sequence[str]],
@@ -714,6 +743,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         body: bytes | Stream,
     ) -> Response: ...
 
@@ -733,6 +763,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         multipart: "Multipart",
     ) -> Response: ...
 
@@ -752,6 +783,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
     ) -> Response: ...
 
     def patch(
@@ -769,6 +801,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         json: Any | None = None,
         form: Union[
             str,
@@ -788,6 +821,7 @@ class Client:
             auth=auth,
             context=context,
             handler=handler,
+            trailers=trailers,
             json=json,
             form=form,
             body=body,
@@ -810,6 +844,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         json: Any,
     ) -> Response: ...
 
@@ -829,6 +864,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         form: Union[
             str,
             Iterable[Sequence[str]],
@@ -853,6 +889,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         body: bytes | Stream,
     ) -> Response: ...
 
@@ -872,6 +909,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         multipart: "Multipart",
     ) -> Response: ...
 
@@ -891,6 +929,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
     ) -> Response: ...
 
     def delete(
@@ -908,6 +947,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         json: Any | None = None,
         form: Union[
             str,
@@ -927,6 +967,7 @@ class Client:
             auth=auth,
             context=context,
             handler=handler,
+            trailers=trailers,
             json=json,
             form=form,
             body=body,
@@ -948,6 +989,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
     ) -> Response:
         return self.request(
             "HEAD",
@@ -957,6 +999,7 @@ class Client:
             auth=auth,
             context=context,
             handler=handler,
+            trailers=trailers,
         )
 
     @overload
@@ -975,6 +1018,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         json: Any,
     ) -> Response: ...
 
@@ -994,6 +1038,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         form: Union[
             str,
             Iterable[Sequence[str]],
@@ -1018,6 +1063,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         body: bytes | Stream,
     ) -> Response: ...
 
@@ -1037,6 +1083,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         multipart: "Multipart",
     ) -> Response: ...
 
@@ -1056,6 +1103,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
     ) -> Response: ...
 
     def query(
@@ -1073,6 +1121,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         json: Any | None = None,
         form: Union[
             str,
@@ -1092,6 +1141,7 @@ class Client:
             auth=auth,
             context=context,
             handler=handler,
+            trailers=trailers,
             json=json,
             form=form,
             body=body,
@@ -1114,6 +1164,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         json: Any,
     ) -> Response: ...
 
@@ -1133,6 +1184,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         form: Union[
             str,
             Iterable[Sequence[str]],
@@ -1157,6 +1209,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         body: bytes | Stream,
     ) -> Response: ...
 
@@ -1176,6 +1229,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         multipart: "Multipart",
     ) -> Response: ...
 
@@ -1195,6 +1249,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
     ) -> Response: ...
 
     def options(
@@ -1212,6 +1267,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         json: Any | None = None,
         form: Union[
             str,
@@ -1231,6 +1287,7 @@ class Client:
             auth=auth,
             context=context,
             handler=handler,
+            trailers=trailers,
             json=json,
             form=form,
             body=body,
@@ -1254,6 +1311,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         json: Any,
     ) -> AbstractContextManager[Response]: ...
 
@@ -1274,6 +1332,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         form: Union[
             str,
             Iterable[Sequence[str]],
@@ -1299,6 +1358,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         body: bytes | Stream,
     ) -> AbstractContextManager[Response]: ...
 
@@ -1319,6 +1379,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         multipart: "Multipart",
     ) -> AbstractContextManager[Response]: ...
 
@@ -1339,6 +1400,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
     ) -> AbstractContextManager[Response]: ...
 
     @contextmanager  # type: ignore
@@ -1358,6 +1420,7 @@ class Client:
         auth: str | tuple[str, str] | None = None,
         context: RequestContext | None = None,
         handler: BaseHandler | HandlerTransform | None = None,
+        trailers: Headers | Mapping[str, str] | None = None,
         json: Any | None = None,
         form: Union[
             str,
@@ -1383,6 +1446,7 @@ class Client:
                 url=url_obj,
                 headers=merged_headers,
                 context=context,
+                trailers=trailers,
                 json=json,
             )
         elif form is not None:
@@ -1391,6 +1455,7 @@ class Client:
                 url=url_obj,
                 headers=merged_headers,
                 context=context,
+                trailers=trailers,
                 form=form,
             )
         elif multipart is not None:
@@ -1399,6 +1464,7 @@ class Client:
                 url=url_obj,
                 headers=merged_headers,
                 context=context,
+                trailers=trailers,
                 multipart=multipart,
             )
         elif body is not None:
@@ -1407,6 +1473,7 @@ class Client:
                 url=url_obj,
                 headers=merged_headers,
                 context=context,
+                trailers=trailers,
                 body=body,
             )
         else:
@@ -1415,6 +1482,7 @@ class Client:
                 url=url_obj,
                 headers=merged_headers,
                 context=context,
+                trailers=trailers,
             )
 
         response = handler.handle(request=request)

--- a/tests/handlers/test_async_cassette.py
+++ b/tests/handlers/test_async_cassette.py
@@ -767,3 +767,45 @@ async def test_empty_body_stored_as_null(
     data = json.loads((tmp_path / "test.json").read_text())
     assert len(data) == 1
     assert data[0]["response"]["body"] == ""
+
+
+async def test_streaming_request_keeps_trailers(
+    tmp_path: Path,
+) -> None:
+    from zapros import Request
+
+    network_requests: list[Request] = []
+
+    def record(request: Request) -> Response:
+        network_requests.append(request)
+        return Response(status=200, text="ok")
+
+    router = MockRouter()
+    Mock.given(path("/upload")).callback(record).mount(router)
+    mock_handler = MockMiddleware(router=router)
+
+    handler = CassetteMiddleware(
+        mock_handler,
+        router=ModifierRouter(),
+        cassette_dir=str(tmp_path),
+        cassette_name="test",
+    )
+
+    async def body():
+        yield b"ab"
+        yield b"cde"
+
+    async with AsyncClient(handler=handler) as client:
+        response = await client.post(
+            "http://example.com/upload",
+            body=body(),
+            trailers={"X-Checksum": "abc"},
+        )
+        await response.aread()
+
+    assert response.status == 200
+    assert len(network_requests) == 1
+    # The cassette materializes streaming bodies into a new Request; trailers must survive.
+    assert network_requests[0].body == b"abcde"
+    assert network_requests[0].trailers is not None
+    assert network_requests[0].trailers["x-checksum"] == "abc"

--- a/tests/handlers/test_async_http1.py
+++ b/tests/handlers/test_async_http1.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from typing import AsyncIterator
+
+from pywhatwgurl import URL
+
+from zapros._async_pool import AsyncHttp1ConnectionPool
+from zapros._handlers._std._async_http1 import AsyncHttp1Connection
+from zapros._io._base import AsyncBaseNetworkStream
+from zapros._models import Headers, Request
+
+
+class AsyncMockStream(AsyncBaseNetworkStream):
+    def __init__(self, buffer: list[bytes]) -> None:
+        self._buffer = list(buffer)
+        self.written = bytearray()
+
+    async def read(self, max_bytes: int, timeout: float | None = None) -> bytes:
+        if not self._buffer:
+            return b""
+        return self._buffer.pop(0)
+
+    async def write_all(self, data: bytes, timeout: float | None = None) -> int:
+        self.written.extend(data)
+        return len(data)
+
+    async def close(self) -> None:
+        pass
+
+
+_OK_RESPONSE = b"HTTP/1.1 200 OK\r\ncontent-length: 0\r\n\r\n"
+
+
+async def test_http1_bytes_body_with_trailers() -> None:
+    stream = AsyncMockStream([_OK_RESPONSE])
+    conn = AsyncHttp1Connection(stream, pool=AsyncHttp1ConnectionPool())
+
+    request = Request(URL("http://example.com/"), "POST", body=b"hello", trailers={"X-Checksum": "abc"})
+    response = await conn.send_request(request)
+
+    assert response.status == 200
+    await response.aread()
+    assert request.headers["Content-Length"] == "5"
+    assert b"content-length" not in stream.written.lower()
+    assert b"transfer-encoding: chunked\r\n" in stream.written.lower()
+    assert b"trailer: x-checksum\r\n" in stream.written.lower()
+    assert stream.written.endswith(b"5\r\nhello\r\n0\r\nX-Checksum: abc\r\n\r\n")
+
+
+async def test_http1_trailers_strip_explicit_content_length() -> None:
+    stream = AsyncMockStream([_OK_RESPONSE])
+    conn = AsyncHttp1Connection(stream, pool=AsyncHttp1ConnectionPool())
+
+    request = Request(
+        URL("http://example.com/"),
+        "POST",
+        headers={"Content-Length": "5"},
+        body=b"hello",
+        trailers={"X-Checksum": "abc"},
+    )
+    response = await conn.send_request(request)
+
+    assert response.status == 200
+    await response.aread()
+    assert b"content-length" not in stream.written.lower()
+    assert b"transfer-encoding: chunked\r\n" in stream.written.lower()
+
+
+async def test_http1_streaming_body_populates_trailers() -> None:
+    stream = AsyncMockStream([_OK_RESPONSE])
+    conn = AsyncHttp1Connection(stream, pool=AsyncHttp1ConnectionPool())
+
+    trailers = Headers()
+
+    async def body() -> AsyncIterator[bytes]:
+        total = 0
+        for chunk in (b"ab", b"cde"):
+            total += len(chunk)
+            yield chunk
+        trailers["X-Total"] = str(total)
+
+    request = Request(URL("http://example.com/"), "POST", body=body(), trailers=trailers)
+    response = await conn.send_request(request)
+
+    assert response.status == 200
+    await response.aread()
+    assert stream.written.endswith(b"2\r\nab\r\n3\r\ncde\r\n0\r\nX-Total: 5\r\n\r\n")
+    assert b"trailer:" not in stream.written.lower()
+
+
+async def test_http1_empty_trailers_end_chunked_body_plainly() -> None:
+    stream = AsyncMockStream([_OK_RESPONSE])
+    conn = AsyncHttp1Connection(stream, pool=AsyncHttp1ConnectionPool())
+
+    request = Request(URL("http://example.com/"), "POST", body=b"hello", trailers={})
+    response = await conn.send_request(request)
+
+    assert response.status == 200
+    await response.aread()
+    assert stream.written.endswith(b"5\r\nhello\r\n0\r\n\r\n")
+
+
+async def test_http1_no_body_with_trailers_uses_chunked_framing() -> None:
+    stream = AsyncMockStream([_OK_RESPONSE])
+    conn = AsyncHttp1Connection(stream, pool=AsyncHttp1ConnectionPool())
+
+    request = Request(URL("http://example.com/"), "POST", trailers={"X-Checksum": "abc"})
+    response = await conn.send_request(request)
+
+    assert response.status == 200
+    await response.aread()
+    assert b"content-length" not in stream.written.lower()
+    assert b"transfer-encoding: chunked\r\n" in stream.written.lower()
+    assert stream.written.endswith(b"\r\n\r\n0\r\nX-Checksum: abc\r\n\r\n")
+
+
+async def test_http1_trailer_header_lists_all_known_fields() -> None:
+    stream = AsyncMockStream([_OK_RESPONSE])
+    conn = AsyncHttp1Connection(stream, pool=AsyncHttp1ConnectionPool())
+
+    request = Request(
+        URL("http://example.com/"),
+        "POST",
+        body=b"hello",
+        trailers=Headers([("X-A", "1"), ("X-B", "2"), ("x-a", "3")]),
+    )
+    response = await conn.send_request(request)
+
+    assert response.status == 200
+    await response.aread()
+    assert b"Trailer: X-A, X-B\r\n" in stream.written
+
+
+async def test_http1_explicit_trailer_header_is_kept() -> None:
+    stream = AsyncMockStream([_OK_RESPONSE])
+    conn = AsyncHttp1Connection(stream, pool=AsyncHttp1ConnectionPool())
+
+    request = Request(
+        URL("http://example.com/"),
+        "POST",
+        headers={"Trailer": "X-Custom"},
+        body=b"hello",
+        trailers={"X-Checksum": "abc"},
+    )
+    response = await conn.send_request(request)
+
+    assert response.status == 200
+    await response.aread()
+    assert stream.written.lower().count(b"trailer:") == 1
+    assert b"trailer: x-custom\r\n" in stream.written.lower()

--- a/tests/handlers/test_sync_cassette.py
+++ b/tests/handlers/test_sync_cassette.py
@@ -767,3 +767,45 @@ def test_empty_body_stored_as_null(
     data = json.loads((tmp_path / "test.json").read_text())
     assert len(data) == 1
     assert data[0]["response"]["body"] == ""
+
+
+def test_streaming_request_keeps_trailers(
+    tmp_path: Path,
+) -> None:
+    from zapros import Request
+
+    network_requests: list[Request] = []
+
+    def record(request: Request) -> Response:
+        network_requests.append(request)
+        return Response(status=200, text="ok")
+
+    router = MockRouter()
+    Mock.given(path("/upload")).callback(record).mount(router)
+    mock_handler = MockMiddleware(router=router)
+
+    handler = CassetteMiddleware(
+        mock_handler,
+        router=ModifierRouter(),
+        cassette_dir=str(tmp_path),
+        cassette_name="test",
+    )
+
+    def body():
+        yield b"ab"
+        yield b"cde"
+
+    with Client(handler=handler) as client:
+        response = client.post(
+            "http://example.com/upload",
+            body=body(),
+            trailers={"X-Checksum": "abc"},
+        )
+        response.read()
+
+    assert response.status == 200
+    assert len(network_requests) == 1
+    # The cassette materializes streaming bodies into a new Request; trailers must survive.
+    assert network_requests[0].body == b"abcde"
+    assert network_requests[0].trailers is not None
+    assert network_requests[0].trailers["x-checksum"] == "abc"

--- a/tests/handlers/test_sync_http1.py
+++ b/tests/handlers/test_sync_http1.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from typing import Iterator
+
+from pywhatwgurl import URL
+
+from zapros._sync_pool import Http1ConnectionPool
+from zapros._handlers._std._sync_http1 import Http1Connection
+from zapros._io._base import BaseNetworkStream
+from zapros._models import Headers, Request
+
+
+class MockStream(BaseNetworkStream):
+    def __init__(self, buffer: list[bytes]) -> None:
+        self._buffer = list(buffer)
+        self.written = bytearray()
+
+    def read(self, max_bytes: int, timeout: float | None = None) -> bytes:
+        if not self._buffer:
+            return b""
+        return self._buffer.pop(0)
+
+    def write_all(self, data: bytes, timeout: float | None = None) -> int:
+        self.written.extend(data)
+        return len(data)
+
+    def close(self) -> None:
+        pass
+
+
+_OK_RESPONSE = b"HTTP/1.1 200 OK\r\ncontent-length: 0\r\n\r\n"
+
+
+def test_http1_bytes_body_with_trailers() -> None:
+    stream = MockStream([_OK_RESPONSE])
+    conn = Http1Connection(stream, pool=Http1ConnectionPool())
+
+    request = Request(URL("http://example.com/"), "POST", body=b"hello", trailers={"X-Checksum": "abc"})
+    response = conn.send_request(request)
+
+    assert response.status == 200
+    response.read()
+    assert request.headers["Content-Length"] == "5"
+    assert b"content-length" not in stream.written.lower()
+    assert b"transfer-encoding: chunked\r\n" in stream.written.lower()
+    assert b"trailer: x-checksum\r\n" in stream.written.lower()
+    assert stream.written.endswith(b"5\r\nhello\r\n0\r\nX-Checksum: abc\r\n\r\n")
+
+
+def test_http1_trailers_strip_explicit_content_length() -> None:
+    stream = MockStream([_OK_RESPONSE])
+    conn = Http1Connection(stream, pool=Http1ConnectionPool())
+
+    request = Request(
+        URL("http://example.com/"),
+        "POST",
+        headers={"Content-Length": "5"},
+        body=b"hello",
+        trailers={"X-Checksum": "abc"},
+    )
+    response = conn.send_request(request)
+
+    assert response.status == 200
+    response.read()
+    assert b"content-length" not in stream.written.lower()
+    assert b"transfer-encoding: chunked\r\n" in stream.written.lower()
+
+
+def test_http1_streaming_body_populates_trailers() -> None:
+    stream = MockStream([_OK_RESPONSE])
+    conn = Http1Connection(stream, pool=Http1ConnectionPool())
+
+    trailers = Headers()
+
+    def body() -> Iterator[bytes]:
+        total = 0
+        for chunk in (b"ab", b"cde"):
+            total += len(chunk)
+            yield chunk
+        trailers["X-Total"] = str(total)
+
+    request = Request(URL("http://example.com/"), "POST", body=body(), trailers=trailers)
+    response = conn.send_request(request)
+
+    assert response.status == 200
+    response.read()
+    assert stream.written.endswith(b"2\r\nab\r\n3\r\ncde\r\n0\r\nX-Total: 5\r\n\r\n")
+    assert b"trailer:" not in stream.written.lower()
+
+
+def test_http1_empty_trailers_end_chunked_body_plainly() -> None:
+    stream = MockStream([_OK_RESPONSE])
+    conn = Http1Connection(stream, pool=Http1ConnectionPool())
+
+    request = Request(URL("http://example.com/"), "POST", body=b"hello", trailers={})
+    response = conn.send_request(request)
+
+    assert response.status == 200
+    response.read()
+    assert stream.written.endswith(b"5\r\nhello\r\n0\r\n\r\n")
+
+
+def test_http1_no_body_with_trailers_uses_chunked_framing() -> None:
+    stream = MockStream([_OK_RESPONSE])
+    conn = Http1Connection(stream, pool=Http1ConnectionPool())
+
+    request = Request(URL("http://example.com/"), "POST", trailers={"X-Checksum": "abc"})
+    response = conn.send_request(request)
+
+    assert response.status == 200
+    response.read()
+    assert b"content-length" not in stream.written.lower()
+    assert b"transfer-encoding: chunked\r\n" in stream.written.lower()
+    assert stream.written.endswith(b"\r\n\r\n0\r\nX-Checksum: abc\r\n\r\n")
+
+
+def test_http1_trailer_header_lists_all_known_fields() -> None:
+    stream = MockStream([_OK_RESPONSE])
+    conn = Http1Connection(stream, pool=Http1ConnectionPool())
+
+    request = Request(
+        URL("http://example.com/"),
+        "POST",
+        body=b"hello",
+        trailers=Headers([("X-A", "1"), ("X-B", "2"), ("x-a", "3")]),
+    )
+    response = conn.send_request(request)
+
+    assert response.status == 200
+    response.read()
+    assert b"Trailer: X-A, X-B\r\n" in stream.written
+
+
+def test_http1_explicit_trailer_header_is_kept() -> None:
+    stream = MockStream([_OK_RESPONSE])
+    conn = Http1Connection(stream, pool=Http1ConnectionPool())
+
+    request = Request(
+        URL("http://example.com/"),
+        "POST",
+        headers={"Trailer": "X-Custom"},
+        body=b"hello",
+        trailers={"X-Checksum": "abc"},
+    )
+    response = conn.send_request(request)
+
+    assert response.status == 200
+    response.read()
+    assert stream.written.lower().count(b"trailer:") == 1
+    assert b"trailer: x-custom\r\n" in stream.written.lower()

--- a/tests/handlers/test_sync_http2.py
+++ b/tests/handlers/test_sync_http2.py
@@ -9,24 +9,24 @@ import pytest
 from pywhatwgurl import URL
 
 from zapros._errors import ConnectionError as ZaprosConnectionError
-from zapros._handlers._std._async_http2 import AsyncHttp2Connection
-from zapros._io._base import AsyncBaseNetworkStream
+from zapros._handlers._std._sync_http2 import Http2Connection
+from zapros._io._base import BaseNetworkStream
 from zapros._models import Headers, Request
 
 
-class AsyncMockStream(AsyncBaseNetworkStream):
+class MockStream(BaseNetworkStream):
     def __init__(self, buffer: list[bytes]) -> None:
         self._buffer = list(buffer)
 
-    async def read(self, max_bytes: int, timeout: float | None = None) -> bytes:
+    def read(self, max_bytes: int, timeout: float | None = None) -> bytes:
         if not self._buffer:
             return b""
         return self._buffer.pop(0)
 
-    async def write_all(self, data: bytes, timeout: float | None = None) -> int:
+    def write_all(self, data: bytes, timeout: float | None = None) -> int:
         return len(data)
 
-    async def close(self) -> None:
+    def close(self) -> None:
         pass
 
 
@@ -49,66 +49,66 @@ def _ok_response_frames(
     ]
 
 
-async def test_http2_get_returns_status_and_body() -> None:
-    stream = AsyncMockStream(_ok_response_frames())
-    conn = AsyncHttp2Connection(stream)
+def test_http2_get_returns_status_and_body() -> None:
+    stream = MockStream(_ok_response_frames())
+    conn = Http2Connection(stream)
 
-    response = await conn.send_request(Request(URL("https://example.com/"), "GET"))
+    response = conn.send_request(Request(URL("https://example.com/"), "GET"))
 
     assert response.status == 200
     assert dict(response.headers.list())["content-type"] == "text/plain"
-    assert await response.aread() == b"Hello, world!"
+    assert response.read() == b"Hello, world!"
 
 
-async def test_http2_post_with_body_completes() -> None:
-    stream = AsyncMockStream(_ok_response_frames())
-    conn = AsyncHttp2Connection(stream)
+def test_http2_post_with_body_completes() -> None:
+    stream = MockStream(_ok_response_frames())
+    conn = Http2Connection(stream)
 
-    response = await conn.send_request(Request(URL("https://example.com/"), "POST", body=b'{"data":"upload"}'))
+    response = conn.send_request(Request(URL("https://example.com/"), "POST", body=b'{"data":"upload"}'))
 
     assert response.status == 200
-    assert await response.aread() == b"Hello, world!"
+    assert response.read() == b"Hello, world!"
 
 
-async def test_http2_stream_reset_raises_before_headers() -> None:
-    stream = AsyncMockStream(
+def test_http2_stream_reset_raises_before_headers() -> None:
+    stream = MockStream(
         [
             hyperframe.frame.SettingsFrame().serialize(),
             hyperframe.frame.RstStreamFrame(stream_id=1, error_code=8).serialize(),
         ]
     )
-    conn = AsyncHttp2Connection(stream)
+    conn = Http2Connection(stream)
 
     with pytest.raises(ZaprosConnectionError, match="stream 1 reset"):
-        await conn.send_request(Request(URL("https://example.com/"), "GET"))
+        conn.send_request(Request(URL("https://example.com/"), "GET"))
 
 
-async def test_http2_goaway_marks_connection_unusable() -> None:
-    stream = AsyncMockStream(
+def test_http2_goaway_marks_connection_unusable() -> None:
+    stream = MockStream(
         _ok_response_frames()
         + [
             hyperframe.frame.GoAwayFrame(stream_id=0, error_code=0, last_stream_id=1).serialize(),
         ]
     )
-    conn = AsyncHttp2Connection(stream)
+    conn = Http2Connection(stream)
 
-    response = await conn.send_request(Request(URL("https://example.com/"), "GET"))
-    assert await response.aread() == b"Hello, world!"
+    response = conn.send_request(Request(URL("https://example.com/"), "GET"))
+    assert response.read() == b"Hello, world!"
 
     assert conn.can_handle_request()
-    await conn._receive_events()
+    conn._receive_events()
     assert not conn.can_handle_request()
 
     with pytest.raises(ZaprosConnectionError, match="terminated by peer"):
-        await conn.send_request(Request(URL("https://example.com/"), "GET"))
+        conn.send_request(Request(URL("https://example.com/"), "GET"))
 
 
-class AsyncRecordingStream(AsyncMockStream):
+class RecordingStream(MockStream):
     def __init__(self, buffer: list[bytes]) -> None:
         super().__init__(buffer)
         self.written = bytearray()
 
-    async def write_all(self, data: bytes, timeout: float | None = None) -> int:
+    def write_all(self, data: bytes, timeout: float | None = None) -> int:
         self.written.extend(data)
         return len(data)
 
@@ -119,14 +119,14 @@ def _server_events(written: bytes) -> list[h2.events.Event]:
     return server.receive_data(written)
 
 
-async def test_http2_bytes_body_with_trailers() -> None:
-    stream = AsyncRecordingStream(_ok_response_frames())
-    conn = AsyncHttp2Connection(stream)
+def test_http2_bytes_body_with_trailers() -> None:
+    stream = RecordingStream(_ok_response_frames())
+    conn = Http2Connection(stream)
 
     request = Request(URL("https://example.com/"), "POST", body=b"hello", trailers={"X-Checksum": "abc"})
-    response = await conn.send_request(request)
+    response = conn.send_request(request)
     assert response.status == 200
-    await response.aread()
+    response.read()
 
     events = _server_events(bytes(stream.written))
     trailers = [e for e in events if isinstance(e, h2.events.TrailersReceived)]
@@ -139,13 +139,13 @@ async def test_http2_bytes_body_with_trailers() -> None:
     assert (b"trailer", b"X-Checksum") in request_received.headers
 
 
-async def test_http2_streaming_body_populates_trailers() -> None:
-    stream = AsyncRecordingStream(_ok_response_frames())
-    conn = AsyncHttp2Connection(stream)
+def test_http2_streaming_body_populates_trailers() -> None:
+    stream = RecordingStream(_ok_response_frames())
+    conn = Http2Connection(stream)
 
     trailers = Headers()
 
-    async def body():
+    def body():
         total = 0
         for chunk in (b"ab", b"cde"):
             total += len(chunk)
@@ -153,9 +153,9 @@ async def test_http2_streaming_body_populates_trailers() -> None:
         trailers["X-Total"] = str(total)
 
     request = Request(URL("https://example.com/"), "POST", body=body(), trailers=trailers)
-    response = await conn.send_request(request)
+    response = conn.send_request(request)
     assert response.status == 200
-    await response.aread()
+    response.read()
 
     events = _server_events(bytes(stream.written))
     data = b"".join(e.data for e in events if isinstance(e, h2.events.DataReceived))
@@ -166,14 +166,14 @@ async def test_http2_streaming_body_populates_trailers() -> None:
     assert not any(k == b"trailer" for k, _ in request_received.headers)
 
 
-async def test_http2_no_body_with_trailers_keeps_stream_open_until_trailers() -> None:
-    stream = AsyncRecordingStream(_ok_response_frames())
-    conn = AsyncHttp2Connection(stream)
+def test_http2_no_body_with_trailers_keeps_stream_open_until_trailers() -> None:
+    stream = RecordingStream(_ok_response_frames())
+    conn = Http2Connection(stream)
 
     request = Request(URL("https://example.com/"), "POST", trailers={"X-Checksum": "abc"})
-    response = await conn.send_request(request)
+    response = conn.send_request(request)
     assert response.status == 200
-    await response.aread()
+    response.read()
 
     events = _server_events(bytes(stream.written))
     request_received = next(e for e in events if isinstance(e, h2.events.RequestReceived))
@@ -183,14 +183,14 @@ async def test_http2_no_body_with_trailers_keeps_stream_open_until_trailers() ->
     assert trailer_event.stream_ended is not None
 
 
-async def test_http2_empty_trailers_end_stream_without_trailer_frame() -> None:
-    stream = AsyncRecordingStream(_ok_response_frames())
-    conn = AsyncHttp2Connection(stream)
+def test_http2_empty_trailers_end_stream_without_trailer_frame() -> None:
+    stream = RecordingStream(_ok_response_frames())
+    conn = Http2Connection(stream)
 
     request = Request(URL("https://example.com/"), "POST", body=b"hello", trailers={})
-    response = await conn.send_request(request)
+    response = conn.send_request(request)
     assert response.status == 200
-    await response.aread()
+    response.read()
 
     events = _server_events(bytes(stream.written))
     assert not any(isinstance(e, h2.events.TrailersReceived) for e in events)

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -18,3 +18,23 @@ async def test_handler_explicit():
     async with AsyncClient() as client:
         with pytest.raises(RuntimeError, match="Error from BrokenHandler"):
             await client.get("https://example.com", handler=BrokenHandler())
+
+
+class CapturingHandler(AsyncBaseHandler):
+    def __init__(self) -> None:
+        self.requests: list[Request] = []
+
+    async def ahandle(self, request: Request) -> Response:
+        self.requests.append(request)
+        return Response(status=200)
+
+
+async def test_request_trailers_passed_through():
+    handler = CapturingHandler()
+    async with AsyncClient(handler=handler) as client:
+        await client.post("https://example.com", body=b"hello", trailers={"X-Checksum": "abc"})
+        await client.get("https://example.com")
+
+    assert handler.requests[0].trailers is not None
+    assert handler.requests[0].trailers["x-checksum"] == "abc"
+    assert handler.requests[1].trailers is None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -386,6 +386,29 @@ class TestRequest:
         request = Request(url, "POST", body=body_gen())
         assert request.headers["Transfer-Encoding"] == "chunked"
 
+    def test_request_trailers_default_none(self):
+        url = URL("http://example.com/path")
+        request = Request(url, "POST", body=b"test")
+        assert request.trailers is None
+
+    def test_request_trailers_are_headers(self):
+        url = URL("http://example.com/path")
+        request = Request(url, "POST", body=b"test", trailers={"X-Checksum": "abc"})
+        assert isinstance(request.trailers, Headers)
+        assert request.trailers["x-checksum"] == "abc"
+
+    def test_request_trailers_keeps_headers_instance(self):
+        url = URL("http://example.com/path")
+        trailers = Headers()
+        request = Request(url, "POST", body=b"test", trailers=trailers)
+        assert request.trailers is trailers
+
+    def test_request_trailers_do_not_change_framing_headers(self):
+        url = URL("http://example.com/path")
+        request = Request(url, "POST", body=b"test", trailers={})
+        assert request.headers["Content-Length"] == "4"
+        assert "Transfer-Encoding" not in request.headers
+
     def test_request_no_body_parameter(self):
         url = URL("http://example.com/path")
         request = Request(url, "GET")

--- a/tests/test_redirect.py
+++ b/tests/test_redirect.py
@@ -432,6 +432,38 @@ async def test_async_redirect_307_preserves_method():
     assert response.status == 200
 
 
+def test_redirect_307_preserves_trailers():
+    router = MockRouter()
+    Mock.given(path("/initial")).respond(
+        Response(
+            status=307,
+            headers={"Location": "/final"},
+        )
+    ).mount(router)
+    final_requests: list[Request] = []
+
+    def record_final(request: Request) -> Response:
+        final_requests.append(request)
+        return Response(status=200, text="OK")
+
+    Mock.given(path("/final")).callback(record_final).mount(router)
+
+    handler = MockMiddleware(router)
+    redirect_handler = RedirectMiddleware(handler)
+
+    request = Request(
+        URL("https://example.com/initial"),
+        "POST",
+        body=b"body",
+        trailers={"X-Checksum": "abc"},
+    )
+    response = redirect_handler.handle(request)
+
+    assert response.status == 200
+    assert len(final_requests) == 1
+    assert final_requests[0].trailers is request.trailers
+
+
 def test_redirect_non_redirect_status_passes_through():
     router = MockRouter()
     Mock.given(path("/")).respond(Response(status=200, text="OK")).mount(router)

--- a/tests/test_sync_client.py
+++ b/tests/test_sync_client.py
@@ -18,3 +18,23 @@ def test_handler_explicit():
     with Client() as client:
         with pytest.raises(RuntimeError, match="Error from BrokenHandler"):
             client.get("https://example.com", handler=BrokenHandler())
+
+
+class CapturingHandler(BaseHandler):
+    def __init__(self) -> None:
+        self.requests: list[Request] = []
+
+    def handle(self, request: Request) -> Response:
+        self.requests.append(request)
+        return Response(status=200)
+
+
+def test_request_trailers_passed_through():
+    handler = CapturingHandler()
+    with Client(handler=handler) as client:
+        client.post("https://example.com", body=b"hello", trailers={"X-Checksum": "abc"})
+        client.get("https://example.com")
+
+    assert handler.requests[0].trailers is not None
+    assert handler.requests[0].trailers["x-checksum"] == "abc"
+    assert handler.requests[1].trailers is None


### PR DESCRIPTION
Zapros can now send trailing headers with a request. The concrete reason is [capo](https://github.com/kap-sh/capo), the S3 client we're building on top of zapros: S3 accepts the checksum of an upload as a trailer, which is the only way to checksum a streaming body without buffering the whole thing first to compute it up front. Trailers are a general HTTP feature though, so here's how it works and a few decisions I'd like eyes on before it ships.

### Usage

```python
resp = await client.post(
    "https://example.com/upload",
    body=data,
    trailers={"X-Checksum": checksum},
)
```

`trailers` is accepted everywhere `headers` is: `Request(...)`, `client.request()`, the method shortcuts and `client.stream()`. It takes a `Headers` or a plain mapping.

The part that matters for capo is that trailers are read *after* the body has been sent, not when the request is built. So a streaming body can fill them in as it goes:

```python
trailers = Headers()

async def body():
    crc = 0
    async for chunk in read_file():
        crc = crc32c(chunk, crc)
        yield chunk
    trailers["x-amz-checksum-crc32c"] = encode(crc)

await client.put(url, body=body(), trailers=trailers)
```

You need to pass the same `Headers` object you mutate — `Request` keeps the instance you give it rather than copying, precisely for this.

### What happens on the wire

HTTP/2 is the easy case. The HEADERS frame goes out without END_STREAM, the body follows, and trailers are sent as a final HEADERS frame with END_STREAM. `content-length` stays on the request if it was there; h2 doesn't care.

HTTP/1.1 only allows trailers in a chunked body, so if `trailers` is set the transport drops `Content-Length` and adds `Transfer-Encoding: chunked` itself. You don't have to think about framing, and `request.headers` is left alone — the rewrite happens when the request is serialized, not on the model.

### The one thing that might surprise you

The transport decides framing based on `trailers is not None`, not on whether it's empty. `trailers={}` or an empty `Headers()` on HTTP/1.1 still switches the request to chunked encoding, even if nothing ends up being sent.
