### PR TITLE
fix: drop unnecessary Headers object creations inside connection_wants_close

### DIFF
--- a/src/zapros/_handlers/_std/_common.py
+++ b/src/zapros/_handlers/_std/_common.py
@@ -12,7 +12,7 @@ from zapros._errors import ConnectionError as _ConnError, TotalTimeoutError
 from zapros._handlers._common import remaining_timeout
 from zapros._headers import Connection
 
-from ..._models import Headers, Request
+from ..._models import Request
 
 
 class BrokenConnectionError(ConnectionError):
@@ -185,7 +185,7 @@ def remaining_timeout_or_raise(deadline: float | None) -> float | None:
 
 
 def connection_wants_close(headers: list[tuple[str, str]]) -> bool:
-    connection_values = Headers(headers).getall("connection")
+    connection_values = [value for key, value in headers if key.casefold() == "connection"]
 
     if not connection_values:
         return False

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -3,11 +3,25 @@ import pytest
 from zapros import Response
 from zapros._constants import CHUNK_SIZE
 from zapros._decoders import ByteChunker
+from zapros._handlers._std._common import connection_wants_close
 
 
 @pytest.fixture(scope="session")
 def body() -> bytes:
     return b"x" * (4 * 1024 * 1024)
+
+
+@pytest.fixture(scope="session")
+def response_headers() -> list[tuple[str, str]]:
+    return [
+        ("Content-Type", "application/x-amz-json-1.0"),
+        ("Content-Length", "204800"),
+        ("Date", "Fri, 29 Aug 2026 00:00:00 GMT"),
+        ("Server", "Server"),
+        ("Connection", "keep-alive"),
+        ("x-amzn-RequestId", "0f1b2c3d-4e5f-6071-8293-a4b5c6d7e8f9"),
+        ("x-amz-crc32", "1234567890"),
+    ]
 
 
 @pytest.fixture(scope="session")
@@ -51,3 +65,8 @@ def test_bench_bytechunker_single_feed(single_feed_body: bytes) -> None:
 def test_bench_iter_bytes_identity_e2e(body_chunks: list[bytes], body: bytes) -> None:
     response = Response(200, content=iter(body_chunks))
     assert sum(len(c) for c in response.iter_bytes()) == len(body)
+
+
+@pytest.mark.benchmark
+def test_bench_connection_wants_close(response_headers: list[tuple[str, str]]) -> None:
+    assert connection_wants_close(response_headers) is False


### PR DESCRIPTION
`_handlers/_std/_async_http1.py:260` calls `connection_wants_close` twice per request:

```python
must_close=connection_wants_close(request_headers_list) or connection_wants_close(resp_headers)
```

I think we can optimise `connection_wants_close` a bit.

`Headers.__init__` (`_models.py:150`)  call inside this function builds a `CIMultiDict`, whose `extend` -> `add` (`_multidict.py:99-123`) casefolds every key, appends to `_items` and does a `setdefault` into `_index`; `getall` then casefolds once more. The whole structure is discarded immediately. For a request/response pair of ~10 headers each that is ~20 casefolds, two dicts and two lists of tuples per request — at ~400 req/s, ~800 wasted multidict builds per second.

Checked with benchmark, new code is a bit better: https://app.codspeed.io/kap-sh/zapros/runs/compare/6a92137782c1b93cd8673e57..6a92141e82c1b93cd8673e68