### PR TITLE
fix: use lazy formatting instead of f-strings in logs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,9 @@ select = ["E", "F", "W", "I", "G"]
 [tool.ruff.lint.isort]
 combine-as-imports = true
 
+[tool.ruff.format]
+exclude = ["docs/**", "skills/**"]
+
 [tool.pyright]
 strict = ["src"]
 exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ dev = [
     "pytest>=9.0.2",
     "pytest-pyodide",
     "pytest-codspeed>=5.0.3",
-    "ruff>=0.14.0",
+    "ruff>=0.16.5",
     "pyright>=1.1.404",
     "pywhatwgurl>=0.1.0",
     "hishel[async]>=1.1.9",
@@ -108,7 +108,7 @@ exclude = [
 ]
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I"]
+select = ["E", "F", "W", "I", "G"]
 
 [tool.ruff.lint.isort]
 combine-as-imports = true

--- a/src/zapros/_handlers/_std/_async.py
+++ b/src/zapros/_handlers/_std/_async.py
@@ -345,7 +345,7 @@ class AsyncStdNetworkHandler(AsyncBaseHandler):
         *,
         connect_timeout: float | None = None,
     ) -> AsyncHttpConnection:
-        logger.debug(f"Establishing new connection for request {request.url.hostname}")
+        logger.debug("Establishing new connection for request %s", request.url.hostname)
         # Target server we ultimately want to talk to
         host = request.url.hostname
         port = get_port_or_default(request.url)
@@ -397,8 +397,12 @@ class AsyncStdNetworkHandler(AsyncBaseHandler):
             alpn_protocols = ["http/1.1"]
 
         logger.debug(
-            f"Connecting to {connect_host}:{connect_port} with TLS={use_tls}, ALPN={alpn_protocols}, "
-            f"proxy={'SOCKS5' if is_socks5 else 'HTTP' if proxy_url else 'None'}"
+            "Connecting to %s:%s with TLS=%s, ALPN=%s, proxy=%s",
+            connect_host,
+            connect_port,
+            use_tls,
+            alpn_protocols,
+            "SOCKS5" if is_socks5 else "HTTP" if proxy_url else "None",
         )
 
         stream = await self.transport.aconnect(
@@ -474,22 +478,22 @@ class AsyncStdNetworkHandler(AsyncBaseHandler):
         Returns a tuple of (connection, from_pool, is_http2).
         """
 
-        logger.debug(f"Trying to acquire connection for {request.url.hostname} from http2 pool")
+        logger.debug("Trying to acquire connection for %s from http2 pool", request.url.hostname)
         # Fast path: existing usable HTTP/2 connection
         http2_conn = cast(AsyncHttp2Connection | None, await self._http2_pool.acquire(key))
         if http2_conn is not None:
-            logger.debug(f"Acquired HTTP/2 connection for {request.url.hostname} from pool")
+            logger.debug("Acquired HTTP/2 connection for %s from pool", request.url.hostname)
             return http2_conn, True, True
 
         # Try HTTP/1 pool
-        logger.debug(f"Trying to acquire connection for {request.url.hostname} from http1 pool")
+        logger.debug("Trying to acquire connection for %s from http1 pool", request.url.hostname)
         conn = cast(AsyncHttpConnection | None, await self._http1_pool.acquire(key))
         if conn is not None:
-            logger.debug(f"Acquired HTTP/1 connection for {request.url.hostname} from pool")
+            logger.debug("Acquired HTTP/1 connection for %s from pool", request.url.hostname)
             return conn, True, False
 
         try:
-            logger.debug(f"No pooled connection available for {request.url.hostname}; establishing new connection")
+            logger.debug("No pooled connection available for %s; establishing new connection", request.url.hostname)
             conn = await self._new_conn(
                 request,
                 connect_timeout=connect_timeout,
@@ -498,7 +502,7 @@ class AsyncStdNetworkHandler(AsyncBaseHandler):
             is_http2 = isinstance(conn, AsyncHttp2Connection)
 
             if is_http2:
-                logger.debug(f"Registering new HTTP/2 connection for {request.url.hostname} in pool")
+                logger.debug("Registering new HTTP/2 connection for %s in pool", request.url.hostname)
                 registered = cast(AsyncHttp2Connection, await self._http2_pool.register(key, conn))
                 await self._http1_pool.release_reservation(key)
                 if registered is not conn:

--- a/src/zapros/_handlers/_std/_sync.py
+++ b/src/zapros/_handlers/_std/_sync.py
@@ -343,7 +343,7 @@ class StdNetworkHandler(BaseHandler):
         *,
         connect_timeout: float | None = None,
     ) -> HttpConnection:
-        logger.debug(f"Establishing new connection for request {request.url.hostname}")
+        logger.debug("Establishing new connection for request %s", request.url.hostname)
         # Target server we ultimately want to talk to
         host = request.url.hostname
         port = get_port_or_default(request.url)
@@ -395,8 +395,12 @@ class StdNetworkHandler(BaseHandler):
             alpn_protocols = ["http/1.1"]
 
         logger.debug(
-            f"Connecting to {connect_host}:{connect_port} with TLS={use_tls}, ALPN={alpn_protocols}, "
-            f"proxy={'SOCKS5' if is_socks5 else 'HTTP' if proxy_url else 'None'}"
+            "Connecting to %s:%s with TLS=%s, ALPN=%s, proxy=%s",
+            connect_host,
+            connect_port,
+            use_tls,
+            alpn_protocols,
+            "SOCKS5" if is_socks5 else "HTTP" if proxy_url else "None",
         )
 
         stream = self.transport.connect(
@@ -472,22 +476,22 @@ class StdNetworkHandler(BaseHandler):
         Returns a tuple of (connection, from_pool, is_http2).
         """
 
-        logger.debug(f"Trying to acquire connection for {request.url.hostname} from http2 pool")
+        logger.debug("Trying to acquire connection for %s from http2 pool", request.url.hostname)
         # Fast path: existing usable HTTP/2 connection
         http2_conn = cast(Http2Connection | None, self._http2_pool.acquire(key))
         if http2_conn is not None:
-            logger.debug(f"Acquired HTTP/2 connection for {request.url.hostname} from pool")
+            logger.debug("Acquired HTTP/2 connection for %s from pool", request.url.hostname)
             return http2_conn, True, True
 
         # Try HTTP/1 pool
-        logger.debug(f"Trying to acquire connection for {request.url.hostname} from http1 pool")
+        logger.debug("Trying to acquire connection for %s from http1 pool", request.url.hostname)
         conn = cast(HttpConnection | None, self._http1_pool.acquire(key))
         if conn is not None:
-            logger.debug(f"Acquired HTTP/1 connection for {request.url.hostname} from pool")
+            logger.debug("Acquired HTTP/1 connection for %s from pool", request.url.hostname)
             return conn, True, False
 
         try:
-            logger.debug(f"No pooled connection available for {request.url.hostname}; establishing new connection")
+            logger.debug("No pooled connection available for %s; establishing new connection", request.url.hostname)
             conn = self._new_conn(
                 request,
                 connect_timeout=connect_timeout,
@@ -496,7 +500,7 @@ class StdNetworkHandler(BaseHandler):
             is_http2 = isinstance(conn, Http2Connection)
 
             if is_http2:
-                logger.debug(f"Registering new HTTP/2 connection for {request.url.hostname} in pool")
+                logger.debug("Registering new HTTP/2 connection for %s in pool", request.url.hostname)
                 registered = cast(Http2Connection, self._http2_pool.register(key, conn))
                 self._http1_pool.release_reservation(key)
                 if registered is not conn:


### PR DESCRIPTION
Using f-strings to format a logging message requires that Python eagerly format the string, even if the logging statement is never executed. This is especially pointless when we are formatting a string for an unused debug log.

To fix and prevent this I enabled new rule for ruff. 

Also I disabled ruff formatting for docs and skills. Because now ruff can format python code inside `md` files and it produces too many changes. Will open separate pull request with them if needed.